### PR TITLE
ContextAwareServiceResolver: Add ContextAwareServiceCollectionResolver that allows context-aware filtering of a pre-propulated service collections (e.g. managed by Declarative Services).

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -27,9 +27,6 @@
       <action type="add" dev="sseifert">
         ContextAwareServiceResolver: Add ContextAwareServiceCollectionResolver that allows context-aware filtering of a pre-propulated service collections (e.g. managed by Declarative Services).
       </action>
-      <action type="add" dev="sseifert">
-        ContextAwareServiceResolver: Support OSGi filter argument to filter resolved services.
-      </action>
     </release>
 
     <release version="1.5.0" date="2022-05-11">

--- a/changes.xml
+++ b/changes.xml
@@ -25,6 +25,9 @@
 
     <release version="1.6.0" date="not released">
       <action type="add" dev="sseifert">
+        ContextAwareServiceResolver: Add ContextAwareServiceCollectionResolver that allows context-aware filtering of a pre-propulated service collections (e.g. managed by Declarative Services).
+      </action>
+      <action type="add" dev="sseifert">
         ContextAwareServiceResolver: Support OSGi filter argument to filter resolved services.
       </action>
     </release>

--- a/src/main/java/io/wcm/sling/commons/caservice/ContextAwareServiceCollectionResolver.java
+++ b/src/main/java/io/wcm/sling/commons/caservice/ContextAwareServiceCollectionResolver.java
@@ -19,7 +19,7 @@
  */
 package io.wcm.sling.commons.caservice;
 
-import java.util.Collection;
+import java.util.stream.Stream;
 
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.adapter.Adaptable;
@@ -60,10 +60,10 @@ public interface ContextAwareServiceCollectionResolver<S extends ContextAwareSer
    * @param adaptable Adaptable which is either a {@link Resource} or {@link SlingHttpServletRequest}.
    *          A resource instance is used directly for matching, in case of request the associated resource is used.
    *          May be null if no context is available.
-   * @return Collection of all matching services
+   * @return All matching services
    */
   @NotNull
-  Collection<S> resolveAll(@Nullable Adaptable adaptable);
+  Stream<S> resolveAll(@Nullable Adaptable adaptable);
 
   /**
    * Resolves the best-matching service implementation for the given resource context.
@@ -73,7 +73,7 @@ public interface ContextAwareServiceCollectionResolver<S extends ContextAwareSer
    * @param adaptable Adaptable which is either a {@link Resource} or {@link SlingHttpServletRequest}.
    *          A resource instance is used directly for matching, in case of request the associated resource is used.
    *          May be null if no context is available.
-   * @return Service implementation or null if no match found.
+   * @return Decorated service implementation or null if no match found.
    */
   @Nullable
   D resolveDecorated(@Nullable Adaptable adaptable);
@@ -86,9 +86,9 @@ public interface ContextAwareServiceCollectionResolver<S extends ContextAwareSer
    * @param adaptable Adaptable which is either a {@link Resource} or {@link SlingHttpServletRequest}.
    *          A resource instance is used directly for matching, in case of request the associated resource is used.
    *          May be null if no context is available.
-   * @return Collection of all matching services
+   * @return All matching decorated services
    */
   @NotNull
-  Collection<D> resolveAllDecorated(@Nullable Adaptable adaptable);
+  Stream<D> resolveAllDecorated(@Nullable Adaptable adaptable);
 
 }

--- a/src/main/java/io/wcm/sling/commons/caservice/ContextAwareServiceCollectionResolver.java
+++ b/src/main/java/io/wcm/sling/commons/caservice/ContextAwareServiceCollectionResolver.java
@@ -1,0 +1,66 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2022 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.sling.commons.caservice;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.adapter.Adaptable;
+import org.apache.sling.api.resource.Resource;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.osgi.annotation.versioning.ProviderType;
+
+import io.wcm.sling.commons.caservice.ContextAwareServiceResolver.ResolveAllResult;
+
+/**
+ * Resolves the best-matching context-aware service implementation.
+ * This is based on a pre-populated collection of service objects in the correct order, so this collection
+ * resolver only filters the list by respecting the resource context and configured service/bundle properties.
+ * @param <T> Service interface or class
+ */
+@ProviderType
+public interface ContextAwareServiceCollectionResolver<T extends ContextAwareService> {
+
+  /**
+   * Resolves the best-matching service implementation for the given resource context.
+   * Only implementations which accept the given context resource path (via the service properties defined in
+   * {@link ContextAwareService}) are considered as candidates.
+   * If multiple candidates exist the implementation with the highest service ranking is returned.
+   * @param adaptable Adaptable which is either a {@link Resource} or {@link SlingHttpServletRequest}.
+   *          A resource instance is used directly for matching, in case of request the associated resource is used.
+   *          May be null if no context is available.
+   * @return Service implementation or null if no match found.
+   */
+  @Nullable
+  T resolve(@Nullable Adaptable adaptable);
+
+  /**
+   * Resolves all matching service implementations for the given resource context.
+   * Only implementations which accept the given context resource path (via the service properties defined in
+   * {@link ContextAwareService}) are considered as candidates.
+   * The candidates are returned ordered descending by their service ranking.
+   * @param adaptable Adaptable which is either a {@link Resource} or {@link SlingHttpServletRequest}.
+   *          A resource instance is used directly for matching, in case of request the associated resource is used.
+   *          May be null if no context is available.
+   * @return Collection of all matching services
+   */
+  @NotNull
+  ResolveAllResult<T> resolveAll(@Nullable Adaptable adaptable);
+
+}

--- a/src/main/java/io/wcm/sling/commons/caservice/ContextAwareServiceCollectionResolver.java
+++ b/src/main/java/io/wcm/sling/commons/caservice/ContextAwareServiceCollectionResolver.java
@@ -19,6 +19,8 @@
  */
 package io.wcm.sling.commons.caservice;
 
+import java.util.Collection;
+
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.adapter.Adaptable;
 import org.apache.sling.api.resource.Resource;
@@ -26,16 +28,16 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.annotation.versioning.ProviderType;
 
-import io.wcm.sling.commons.caservice.ContextAwareServiceResolver.ResolveAllResult;
-
 /**
  * Resolves the best-matching context-aware service implementation.
  * This is based on a pre-populated collection of service objects in the correct order, so this collection
  * resolver only filters the list by respecting the resource context and configured service/bundle properties.
- * @param <T> Service interface or class
+ * The services in the collections are expected to be sorted by ranking (highest to lowest).
+ * @param <S> Service interface or class
+ * @param <D> Decorator class that is calculated once for each item of the service objects collection.
  */
 @ProviderType
-public interface ContextAwareServiceCollectionResolver<T extends ContextAwareService> {
+public interface ContextAwareServiceCollectionResolver<S extends ContextAwareService, D> {
 
   /**
    * Resolves the best-matching service implementation for the given resource context.
@@ -48,10 +50,10 @@ public interface ContextAwareServiceCollectionResolver<T extends ContextAwareSer
    * @return Service implementation or null if no match found.
    */
   @Nullable
-  T resolve(@Nullable Adaptable adaptable);
+  S resolve(@Nullable Adaptable adaptable);
 
   /**
-   * Resolves all matching service implementations for the given resource context.
+   * Resolves all matching service implementations for the given resource context wrapped in it's decorator.
    * Only implementations which accept the given context resource path (via the service properties defined in
    * {@link ContextAwareService}) are considered as candidates.
    * The candidates are returned ordered descending by their service ranking.
@@ -61,6 +63,32 @@ public interface ContextAwareServiceCollectionResolver<T extends ContextAwareSer
    * @return Collection of all matching services
    */
   @NotNull
-  ResolveAllResult<T> resolveAll(@Nullable Adaptable adaptable);
+  Collection<S> resolveAll(@Nullable Adaptable adaptable);
+
+  /**
+   * Resolves the best-matching service implementation for the given resource context.
+   * Only implementations which accept the given context resource path (via the service properties defined in
+   * {@link ContextAwareService}) are considered as candidates.
+   * If multiple candidates exist the implementation with the highest service ranking is returned.
+   * @param adaptable Adaptable which is either a {@link Resource} or {@link SlingHttpServletRequest}.
+   *          A resource instance is used directly for matching, in case of request the associated resource is used.
+   *          May be null if no context is available.
+   * @return Service implementation or null if no match found.
+   */
+  @Nullable
+  D resolveDecorated(@Nullable Adaptable adaptable);
+
+  /**
+   * Resolves all matching service implementations for the given resource context each one wrapped in it's decorator.
+   * Only implementations which accept the given context resource path (via the service properties defined in
+   * {@link ContextAwareService}) are considered as candidates.
+   * The candidates are returned ordered descending by their service ranking.
+   * @param adaptable Adaptable which is either a {@link Resource} or {@link SlingHttpServletRequest}.
+   *          A resource instance is used directly for matching, in case of request the associated resource is used.
+   *          May be null if no context is available.
+   * @return Collection of all matching services
+   */
+  @NotNull
+  Collection<D> resolveAllDecorated(@Nullable Adaptable adaptable);
 
 }

--- a/src/main/java/io/wcm/sling/commons/caservice/ContextAwareServiceResolver.java
+++ b/src/main/java/io/wcm/sling/commons/caservice/ContextAwareServiceResolver.java
@@ -19,6 +19,7 @@
  */
 package io.wcm.sling.commons.caservice;
 
+import java.util.Collection;
 import java.util.stream.Stream;
 
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -28,6 +29,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.annotation.versioning.ProviderType;
 import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceObjects;
 
 /**
  * Resolves the best-matching context-aware service implementation.
@@ -47,7 +49,7 @@ public interface ContextAwareServiceResolver {
    * @param <T> Service interface or class
    * @return Service implementation or null if no match found.
    */
-  <T extends ContextAwareService> @Nullable T resolve(@NotNull Class<T> serviceClass, @NotNull Adaptable adaptable);
+  <T extends ContextAwareService> @Nullable T resolve(@NotNull Class<T> serviceClass, @Nullable Adaptable adaptable);
 
   /**
    * Resolves the best-matching service implementation for the given resource context.
@@ -63,7 +65,7 @@ public interface ContextAwareServiceResolver {
    * @return Service implementation or null if no match found.
    * @throws InvalidSyntaxException If the specified filter contains an invalid filter expression that cannot be parsed.
    */
-  <T extends ContextAwareService> @Nullable T resolve(@NotNull Class<T> serviceClass, @NotNull Adaptable adaptable,
+  <T extends ContextAwareService> @Nullable T resolve(@NotNull Class<T> serviceClass, @Nullable Adaptable adaptable,
       @Nullable String filter) throws InvalidSyntaxException;
 
   /**
@@ -78,7 +80,7 @@ public interface ContextAwareServiceResolver {
    * @param <T> Service interface or class
    * @return Collection of all matching services
    */
-  <T extends ContextAwareService> @NotNull ResolveAllResult<T> resolveAll(@NotNull Class<T> serviceClass, @NotNull Adaptable adaptable);
+  <T extends ContextAwareService> @NotNull ResolveAllResult<T> resolveAll(@NotNull Class<T> serviceClass, @Nullable Adaptable adaptable);
 
   /**
    * Resolves all matching service implementations for the given resource context.
@@ -94,8 +96,20 @@ public interface ContextAwareServiceResolver {
    * @return Collection of all matching services
    * @throws InvalidSyntaxException If the specified filter contains an invalid filter expression that cannot be parsed.
    */
-  <T extends ContextAwareService> @NotNull ResolveAllResult<T> resolveAll(@NotNull Class<T> serviceClass, @NotNull Adaptable adaptable,
+  <T extends ContextAwareService> @NotNull ResolveAllResult<T> resolveAll(@NotNull Class<T> serviceClass, @Nullable Adaptable adaptable,
       @Nullable String filter) throws InvalidSyntaxException;
+
+  /**
+   * Gets a {@link ContextAwareServiceCollectionResolver} which operates on a given collection of service objects
+   * of the required service. This collection is usually managed by OSGi Declarative Services and expected
+   * to contain all services with the service interface order by service ranking (high to low).
+   * The collection resolver helps to get service(s) matching the resource context out of this list.
+   * @param <T> Service interface or class
+   * @param serviceObjectsCollection Collection of service objects
+   * @return Collection resolver
+   */
+  <T extends ContextAwareService> @NotNull ContextAwareServiceCollectionResolver<T> getCollectionResolver(
+      @NotNull Collection<ServiceObjects<T>> serviceObjectsCollection);
 
   /**
    * Result of the {@link ContextAwareServiceResolver#resolveAll(Class, Adaptable)} method.

--- a/src/main/java/io/wcm/sling/commons/caservice/ContextAwareServiceResolver.java
+++ b/src/main/java/io/wcm/sling/commons/caservice/ContextAwareServiceResolver.java
@@ -29,7 +29,7 @@ import org.apache.sling.api.resource.Resource;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.annotation.versioning.ProviderType;
-import org.osgi.framework.ServiceObjects;
+import org.osgi.service.component.ComponentServiceObjects;
 
 /**
  * Resolves the best-matching context-aware service implementation.
@@ -75,7 +75,7 @@ public interface ContextAwareServiceResolver {
    * @return Collection resolver
    */
   <S extends ContextAwareService> @NotNull ContextAwareServiceCollectionResolver<S, Void> getCollectionResolver(
-      @NotNull Collection<ServiceObjects<S>> serviceObjectsCollection);
+      @NotNull Collection<ComponentServiceObjects<S>> serviceObjectsCollection);
 
   /**
    * Gets a {@link ContextAwareServiceCollectionResolver} which operates on a given collection of service objects
@@ -89,8 +89,8 @@ public interface ContextAwareServiceResolver {
    * @return Collection resolver
    */
   <S extends ContextAwareService, D> @NotNull ContextAwareServiceCollectionResolver<S, D> getCollectionResolver(
-      @NotNull Collection<ServiceObjects<S>> serviceObjectsCollection,
-      Function<ServiceObjects<S>, D> decorator);
+      @NotNull Collection<ComponentServiceObjects<S>> serviceObjectsCollection,
+      Function<ComponentServiceObjects<S>, D> decorator);
 
   /**
    * Result of the {@link ContextAwareServiceResolver#resolveAll(Class, Adaptable)} method.

--- a/src/main/java/io/wcm/sling/commons/caservice/ContextAwareServiceResolver.java
+++ b/src/main/java/io/wcm/sling/commons/caservice/ContextAwareServiceResolver.java
@@ -20,6 +20,7 @@
 package io.wcm.sling.commons.caservice;
 
 import java.util.Collection;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -45,10 +46,10 @@ public interface ContextAwareServiceResolver {
    * @param adaptable Adaptable which is either a {@link Resource} or {@link SlingHttpServletRequest}.
    *          A resource instance is used directly for matching, in case of request the associated resource is used.
    *          May be null if no context is available.
-   * @param <T> Service interface or class
+   * @param <S> Service interface or class
    * @return Service implementation or null if no match found.
    */
-  <T extends ContextAwareService> @Nullable T resolve(@NotNull Class<T> serviceClass, @Nullable Adaptable adaptable);
+  <S extends ContextAwareService> @Nullable S resolve(@NotNull Class<S> serviceClass, @Nullable Adaptable adaptable);
 
   /**
    * Resolves all matching service implementations for the given resource context.
@@ -59,36 +60,51 @@ public interface ContextAwareServiceResolver {
    * @param adaptable Adaptable which is either a {@link Resource} or {@link SlingHttpServletRequest}.
    *          A resource instance is used directly for matching, in case of request the associated resource is used.
    *          May be null if no context is available.
-   * @param <T> Service interface or class
+   * @param <S> Service interface or class
    * @return Collection of all matching services
    */
-  <T extends ContextAwareService> @NotNull ResolveAllResult<T> resolveAll(@NotNull Class<T> serviceClass, @Nullable Adaptable adaptable);
+  <S extends ContextAwareService> @NotNull ResolveAllResult<S> resolveAll(@NotNull Class<S> serviceClass, @Nullable Adaptable adaptable);
 
   /**
    * Gets a {@link ContextAwareServiceCollectionResolver} which operates on a given collection of service objects
    * of the required service. This collection is usually managed by OSGi Declarative Services and expected
    * to contain all services with the service interface order by service ranking (high to low).
    * The collection resolver helps to get service(s) matching the resource context out of this list.
-   * @param <T> Service interface or class
+   * @param <S> Service interface or class
    * @param serviceObjectsCollection Collection of service objects
    * @return Collection resolver
    */
-  <T extends ContextAwareService> @NotNull ContextAwareServiceCollectionResolver<T> getCollectionResolver(
-      @NotNull Collection<ServiceObjects<T>> serviceObjectsCollection);
+  <S extends ContextAwareService> @NotNull ContextAwareServiceCollectionResolver<S, Void> getCollectionResolver(
+      @NotNull Collection<ServiceObjects<S>> serviceObjectsCollection);
+
+  /**
+   * Gets a {@link ContextAwareServiceCollectionResolver} which operates on a given collection of service objects
+   * of the required service. This collection is usually managed by OSGi Declarative Services and expected
+   * to contain all services with the service interface order by service ranking (high to low).
+   * The collection resolver helps to get service(s) matching the resource context out of this list.
+   * @param <S> Service interface or class
+   * @param <D> Decorator class that is calculated once for each item of the service objects collection.
+   * @param serviceObjectsCollection Collection of service objects
+   * @param decorator Creates decoration for each collection item once.
+   * @return Collection resolver
+   */
+  <S extends ContextAwareService, D> @NotNull ContextAwareServiceCollectionResolver<S, D> getCollectionResolver(
+      @NotNull Collection<ServiceObjects<S>> serviceObjectsCollection,
+      Function<ServiceObjects<S>, D> decorator);
 
   /**
    * Result of the {@link ContextAwareServiceResolver#resolveAll(Class, Adaptable)} method.
    * All methods are implemented in a lazy fashion.
-   * @param <T> Service interface or class
+   * @param <S> Service interface or class
    */
-  interface ResolveAllResult<T extends ContextAwareService> {
+  interface ResolveAllResult<S extends ContextAwareService> {
 
     /**
      * Gets all matching services
      * @return Context-Aware services
      */
     @NotNull
-    Stream<T> getServices();
+    Stream<S> getServices();
 
     /**
      * Gets a combined key that represents the path filter sets of all affected context-aware services

--- a/src/main/java/io/wcm/sling/commons/caservice/ContextAwareServiceResolver.java
+++ b/src/main/java/io/wcm/sling/commons/caservice/ContextAwareServiceResolver.java
@@ -28,7 +28,6 @@ import org.apache.sling.api.resource.Resource;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.annotation.versioning.ProviderType;
-import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceObjects;
 
 /**
@@ -52,23 +51,6 @@ public interface ContextAwareServiceResolver {
   <T extends ContextAwareService> @Nullable T resolve(@NotNull Class<T> serviceClass, @Nullable Adaptable adaptable);
 
   /**
-   * Resolves the best-matching service implementation for the given resource context.
-   * Only implementations which accept the given context resource path (via the service properties defined in
-   * {@link ContextAwareService}) are considered as candidates.
-   * If multiple candidates exist the implementation with the highest service ranking is returned.
-   * @param serviceClass Service interface or class
-   * @param adaptable Adaptable which is either a {@link Resource} or {@link SlingHttpServletRequest}.
-   *          A resource instance is used directly for matching, in case of request the associated resource is used.
-   *          May be null if no context is available.
-   * @param filter OSGi filter expression or null for all services
-   * @param <T> Service interface or class
-   * @return Service implementation or null if no match found.
-   * @throws InvalidSyntaxException If the specified filter contains an invalid filter expression that cannot be parsed.
-   */
-  <T extends ContextAwareService> @Nullable T resolve(@NotNull Class<T> serviceClass, @Nullable Adaptable adaptable,
-      @Nullable String filter) throws InvalidSyntaxException;
-
-  /**
    * Resolves all matching service implementations for the given resource context.
    * Only implementations which accept the given context resource path (via the service properties defined in
    * {@link ContextAwareService}) are considered as candidates.
@@ -81,23 +63,6 @@ public interface ContextAwareServiceResolver {
    * @return Collection of all matching services
    */
   <T extends ContextAwareService> @NotNull ResolveAllResult<T> resolveAll(@NotNull Class<T> serviceClass, @Nullable Adaptable adaptable);
-
-  /**
-   * Resolves all matching service implementations for the given resource context.
-   * Only implementations which accept the given context resource path (via the service properties defined in
-   * {@link ContextAwareService}) are considered as candidates.
-   * The candidates are returned ordered descending by their service ranking.
-   * @param serviceClass Service interface or class
-   * @param adaptable Adaptable which is either a {@link Resource} or {@link SlingHttpServletRequest}.
-   *          A resource instance is used directly for matching, in case of request the associated resource is used.
-   *          May be null if no context is available.
-   * @param filter OSGi filter expression or null for all services
-   * @param <T> Service interface or class
-   * @return Collection of all matching services
-   * @throws InvalidSyntaxException If the specified filter contains an invalid filter expression that cannot be parsed.
-   */
-  <T extends ContextAwareService> @NotNull ResolveAllResult<T> resolveAll(@NotNull Class<T> serviceClass, @Nullable Adaptable adaptable,
-      @Nullable String filter) throws InvalidSyntaxException;
 
   /**
    * Gets a {@link ContextAwareServiceCollectionResolver} which operates on a given collection of service objects

--- a/src/main/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceCollectionResolverImpl.java
+++ b/src/main/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceCollectionResolverImpl.java
@@ -68,7 +68,7 @@ class ContextAwareServiceCollectionResolverImpl<T extends ContextAwareService>
   private Stream<ServiceInfo<T>> getMatchingServiceInfos(@Nullable Adaptable adaptable) {
     String resourcePath = resolverHelper.getResourcePath(adaptable);
     return services.stream()
-        .filter(service -> service.matchesPath(resourcePath));
+        .filter(service -> service.matches(resourcePath));
   }
 
 }

--- a/src/main/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceCollectionResolverImpl.java
+++ b/src/main/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceCollectionResolverImpl.java
@@ -1,0 +1,74 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2022 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.sling.commons.caservice.impl;
+
+import java.util.Collection;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.sling.api.adapter.Adaptable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.osgi.framework.ServiceObjects;
+
+import io.wcm.sling.commons.caservice.ContextAwareService;
+import io.wcm.sling.commons.caservice.ContextAwareServiceCollectionResolver;
+import io.wcm.sling.commons.caservice.ContextAwareServiceResolver.ResolveAllResult;
+
+class ContextAwareServiceCollectionResolverImpl<T extends ContextAwareService>
+    implements ContextAwareServiceCollectionResolver<T> {
+
+  private final Collection<ServiceInfo<T>> services;
+  private final ResolverHelper resolverHelper;
+  private final long timestamp;
+
+  @SuppressWarnings("null")
+  ContextAwareServiceCollectionResolverImpl(@NotNull Collection<ServiceObjects<T>> serviceObjectsCollection,
+      @NotNull ResolverHelper resolverHelper) {
+    this.services = serviceObjectsCollection.stream()
+        .map(serviceObjects -> new ServiceInfo<T>(serviceObjects.getServiceReference(), serviceObjects.getService()))
+        .filter(ServiceInfo::isValid)
+        .collect(Collectors.toList());
+    this.resolverHelper = resolverHelper;
+    this.timestamp = System.currentTimeMillis();
+  }
+
+  @Override
+  @SuppressWarnings("null")
+  public @Nullable T resolve(@Nullable Adaptable adaptable) {
+    return resolverHelper.getValidServices(getMatchingServiceInfos(adaptable))
+        .findFirst().orElse(null);
+  }
+
+  @Override
+  public @NotNull ResolveAllResult<T> resolveAll(@Nullable Adaptable adaptable) {
+    Stream<T> matchingServices = resolverHelper.getValidServices(getMatchingServiceInfos(adaptable));
+    Supplier<String> combinedKey = resolverHelper.buildCombinedKey(timestamp, getMatchingServiceInfos(adaptable));
+    return new ResolveAllResultImpl<>(matchingServices, combinedKey);
+  }
+
+  private Stream<ServiceInfo<T>> getMatchingServiceInfos(@Nullable Adaptable adaptable) {
+    String resourcePath = resolverHelper.getResourcePath(adaptable);
+    return services.stream()
+        .filter(service -> service.matchesPath(resourcePath));
+  }
+
+}

--- a/src/main/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceCollectionResolverImpl.java
+++ b/src/main/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceCollectionResolverImpl.java
@@ -57,10 +57,9 @@ class ContextAwareServiceCollectionResolverImpl<S extends ContextAwareService, D
 
   @Override
   @SuppressWarnings("null")
-  public @NotNull Collection<S> resolveAll(@Nullable Adaptable adaptable) {
+  public @NotNull Stream<S> resolveAll(@Nullable Adaptable adaptable) {
     return getMatching(adaptable)
-        .map(ServiceWrapper::getService)
-        .collect(Collectors.toList());
+        .map(ServiceWrapper::getService);
   }
 
   @Override
@@ -73,10 +72,9 @@ class ContextAwareServiceCollectionResolverImpl<S extends ContextAwareService, D
 
   @Override
   @SuppressWarnings("null")
-  public @NotNull Collection<D> resolveAllDecorated(@Nullable Adaptable adaptable) {
+  public @NotNull Stream<D> resolveAllDecorated(@Nullable Adaptable adaptable) {
     return getMatching(adaptable)
-        .map(ServiceWrapper::getDecoration)
-        .collect(Collectors.toList());
+        .map(ServiceWrapper::getDecoration);
   }
 
   private Stream<ServiceWrapper<S, D>> getMatching(@Nullable Adaptable adaptable) {

--- a/src/main/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceCollectionResolverImpl.java
+++ b/src/main/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceCollectionResolverImpl.java
@@ -36,15 +36,15 @@ class ContextAwareServiceCollectionResolverImpl<S extends ContextAwareService, D
     implements ContextAwareServiceCollectionResolver<S, D> {
 
   private final Collection<ServiceWrapper<S, D>> services;
-  private final ResolverHelper resolverHelper;
+  private final ResourcePathResolver resourcePathResolver;
 
   ContextAwareServiceCollectionResolverImpl(@NotNull Collection<ServiceObjects<S>> serviceObjectsCollection,
-      Function<ServiceObjects<S>, D> decorator, @NotNull ResolverHelper resolverHelper) {
+      Function<ServiceObjects<S>, D> decorator, @NotNull ResourcePathResolver resourcePathResolver) {
     this.services = serviceObjectsCollection.stream()
         .map(serviceObjects -> new ServiceWrapper<>(serviceObjects, decorator))
         .filter(ServiceWrapper::isValid)
         .collect(Collectors.toList());
-    this.resolverHelper = resolverHelper;
+    this.resourcePathResolver = resourcePathResolver;
   }
 
   @Override
@@ -80,7 +80,7 @@ class ContextAwareServiceCollectionResolverImpl<S extends ContextAwareService, D
   }
 
   private Stream<ServiceWrapper<S, D>> getMatching(@Nullable Adaptable adaptable) {
-    String resourcePath = resolverHelper.getResourcePath(adaptable);
+    String resourcePath = resourcePathResolver.get(adaptable);
     return services.stream()
         .filter(wrapper -> wrapper.matches(resourcePath));
   }

--- a/src/main/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceCollectionResolverImpl.java
+++ b/src/main/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceCollectionResolverImpl.java
@@ -27,7 +27,7 @@ import java.util.stream.Stream;
 import org.apache.sling.api.adapter.Adaptable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.osgi.framework.ServiceObjects;
+import org.osgi.service.component.ComponentServiceObjects;
 
 import io.wcm.sling.commons.caservice.ContextAwareService;
 import io.wcm.sling.commons.caservice.ContextAwareServiceCollectionResolver;
@@ -38,8 +38,8 @@ class ContextAwareServiceCollectionResolverImpl<S extends ContextAwareService, D
   private final Collection<ServiceWrapper<S, D>> services;
   private final ResourcePathResolver resourcePathResolver;
 
-  ContextAwareServiceCollectionResolverImpl(@NotNull Collection<ServiceObjects<S>> serviceObjectsCollection,
-      Function<ServiceObjects<S>, D> decorator, @NotNull ResourcePathResolver resourcePathResolver) {
+  ContextAwareServiceCollectionResolverImpl(@NotNull Collection<ComponentServiceObjects<S>> serviceObjectsCollection,
+      Function<ComponentServiceObjects<S>, D> decorator, @NotNull ResourcePathResolver resourcePathResolver) {
     this.services = serviceObjectsCollection.stream()
         .map(serviceObjects -> new ServiceWrapper<>(serviceObjects, decorator))
         .filter(ServiceWrapper::isValid)
@@ -89,7 +89,7 @@ class ContextAwareServiceCollectionResolverImpl<S extends ContextAwareService, D
     private final D decoration;
     private final ServiceInfo<S> serviceInfo;
 
-    ServiceWrapper(ServiceObjects<S> serviceObjects, Function<ServiceObjects<S>, D> decorator) {
+    ServiceWrapper(ComponentServiceObjects<S> serviceObjects, Function<ComponentServiceObjects<S>, D> decorator) {
       this.service = serviceObjects.getService();
       this.decoration = decorator.apply(serviceObjects);
       this.serviceInfo = new ServiceInfo<>(serviceObjects.getServiceReference(), this.service);

--- a/src/main/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceInventoryPrinter.java
+++ b/src/main/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceInventoryPrinter.java
@@ -66,7 +66,7 @@ public class ContextAwareServiceInventoryPrinter implements InventoryPrinter {
       pw.println();
       pw.println(entry.getKey());
       pw.println(StringUtils.repeat('-', entry.getKey().length()));
-      for (ServiceInfo<?> serviceInfo : entry.getValue().getServiceInfos()) {
+      for (ServiceInfo<ContextAwareService> serviceInfo : entry.getValue().getServiceInfos()) {
         pw.print("- ");
         pw.println(serviceInfo.toString());
       }

--- a/src/main/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceInventoryPrinter.java
+++ b/src/main/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceInventoryPrinter.java
@@ -29,6 +29,7 @@ import org.apache.felix.inventory.InventoryPrinter;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
+import io.wcm.sling.commons.caservice.ContextAwareService;
 import io.wcm.sling.commons.caservice.ContextAwareServiceResolver;
 
 /**
@@ -53,18 +54,19 @@ public class ContextAwareServiceInventoryPrinter implements InventoryPrinter {
       return;
     }
 
-    ConcurrentMap<String, ContextAwareServiceTracker> map = ((ContextAwareServiceResolverImpl)contextAwareServiceResolver).getContextAwareServiceTrackerMap();
+    ConcurrentMap<String, ContextAwareServiceTracker<ContextAwareService>> map = ((ContextAwareServiceResolverImpl)contextAwareServiceResolver)
+        .getContextAwareServiceTrackerMap();
     if (map.isEmpty()) {
       pw.println();
       pw.println("No context-aware services found.");
       pw.println("The services are registered lazily on first access of the service interface or class.");
       return;
     }
-    for (Map.Entry<String, ContextAwareServiceTracker> entry : map.entrySet()) {
+    for (Map.Entry<String, ContextAwareServiceTracker<ContextAwareService>> entry : map.entrySet()) {
       pw.println();
       pw.println(entry.getKey());
       pw.println(StringUtils.repeat('-', entry.getKey().length()));
-      for (ServiceInfo serviceInfo : entry.getValue().getServiceInfos()) {
+      for (ServiceInfo<?> serviceInfo : entry.getValue().getServiceInfos()) {
         pw.print("- ");
         pw.println(serviceInfo.toString());
       }

--- a/src/main/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceResolverImpl.java
+++ b/src/main/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceResolverImpl.java
@@ -22,6 +22,7 @@ package io.wcm.sling.commons.caservice.impl;
 import java.util.Collection;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -115,9 +116,15 @@ public class ContextAwareServiceResolverImpl implements ContextAwareServiceResol
   }
 
   @Override
-  public <T extends ContextAwareService> @NotNull ContextAwareServiceCollectionResolver<T> getCollectionResolver(
-      @NotNull Collection<ServiceObjects<T>> serviceObjectsCollection) {
-    return new ContextAwareServiceCollectionResolverImpl<>(serviceObjectsCollection, resolverHelper);
+  public <S extends ContextAwareService> @NotNull ContextAwareServiceCollectionResolver<S, Void> getCollectionResolver(
+      @NotNull Collection<ServiceObjects<S>> serviceObjectsCollection) {
+    return getCollectionResolver(serviceObjectsCollection, item -> null);
+  }
+
+  @Override
+  public <S extends ContextAwareService, D> @NotNull ContextAwareServiceCollectionResolver<S, D> getCollectionResolver(
+      @NotNull Collection<ServiceObjects<S>> serviceObjectsCollection, Function<ServiceObjects<S>, D> decorator) {
+    return new ContextAwareServiceCollectionResolverImpl<>(serviceObjectsCollection, decorator, resolverHelper);
   }
 
   private <T extends ContextAwareService> Stream<ServiceInfo<T>> getMatchingServiceInfos(

--- a/src/main/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceResolverImpl.java
+++ b/src/main/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceResolverImpl.java
@@ -31,7 +31,7 @@ import org.apache.sling.api.adapter.Adaptable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.ServiceObjects;
+import org.osgi.service.component.ComponentServiceObjects;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
@@ -118,13 +118,14 @@ public class ContextAwareServiceResolverImpl implements ContextAwareServiceResol
 
   @Override
   public <S extends ContextAwareService> @NotNull ContextAwareServiceCollectionResolver<S, Void> getCollectionResolver(
-      @NotNull Collection<ServiceObjects<S>> serviceObjectsCollection) {
+      @NotNull Collection<ComponentServiceObjects<S>> serviceObjectsCollection) {
     return getCollectionResolver(serviceObjectsCollection, item -> null);
   }
 
   @Override
   public <S extends ContextAwareService, D> @NotNull ContextAwareServiceCollectionResolver<S, D> getCollectionResolver(
-      @NotNull Collection<ServiceObjects<S>> serviceObjectsCollection, Function<ServiceObjects<S>, D> decorator) {
+      @NotNull Collection<ComponentServiceObjects<S>> serviceObjectsCollection,
+      Function<ComponentServiceObjects<S>, D> decorator) {
     return new ContextAwareServiceCollectionResolverImpl<>(serviceObjectsCollection, decorator, resourcePathResolver);
   }
 

--- a/src/main/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceTracker.java
+++ b/src/main/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceTracker.java
@@ -21,9 +21,9 @@ package io.wcm.sling.commons.caservice.impl;
 
 import java.util.stream.Stream;
 
-import org.apache.sling.api.resource.Resource;
 import org.apache.sling.commons.osgi.Order;
 import org.apache.sling.commons.osgi.RankedServices;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Filter;
@@ -34,21 +34,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.wcm.sling.commons.caservice.ContextAwareService;
-import io.wcm.sling.commons.caservice.PathPreprocessor;
 
-class ContextAwareServiceTracker implements ServiceTrackerCustomizer<ContextAwareService, ServiceInfo> {
+class ContextAwareServiceTracker<T extends ContextAwareService> implements ServiceTrackerCustomizer<T, ServiceInfo<T>> {
 
+  private final String serviceClassName;
   private final BundleContext bundleContext;
-  private final PathPreprocessor pathPreprocessor;
-  private final ServiceTracker<ContextAwareService, ServiceInfo> serviceTracker;
-  private volatile RankedServices<ServiceInfo> rankedServices;
+  private final ServiceTracker<T, ServiceInfo<T>> serviceTracker;
+  private volatile RankedServices<ServiceInfo<T>> rankedServices;
   private volatile long lastServiceChange;
 
   private static final Logger log = LoggerFactory.getLogger(ContextAwareServiceTracker.class);
 
-  ContextAwareServiceTracker(String serviceClassName, BundleContext bundleContext, PathPreprocessor pathPreprocessor) {
+  ContextAwareServiceTracker(@NotNull String serviceClassName, @NotNull BundleContext bundleContext) {
+    this.serviceClassName = serviceClassName;
     this.bundleContext = bundleContext;
-    this.pathPreprocessor = pathPreprocessor;
     this.rankedServices = new RankedServices<>(Order.DESCENDING);
     this.serviceTracker = new ServiceTracker<>(bundleContext, serviceClassName, this);
     this.serviceTracker.open();
@@ -60,11 +59,9 @@ class ContextAwareServiceTracker implements ServiceTrackerCustomizer<ContextAwar
   }
 
   @Override
-  public ServiceInfo addingService(ServiceReference<ContextAwareService> reference) {
-    ServiceInfo serviceInfo = new ServiceInfo(reference, bundleContext);
-    if (log.isDebugEnabled()) {
-      log.debug("Add service {}", serviceInfo.getService().getClass().getName());
-    }
+  public ServiceInfo addingService(ServiceReference<T> reference) {
+    ServiceInfo<T> serviceInfo = new ServiceInfo<>(reference, bundleContext);
+    logServiceDebugMessage("Add service {}", serviceInfo);
     if (rankedServices != null) {
       rankedServices.bind(serviceInfo, serviceInfo.getServiceProperties());
     }
@@ -73,15 +70,13 @@ class ContextAwareServiceTracker implements ServiceTrackerCustomizer<ContextAwar
   }
 
   @Override
-  public void modifiedService(ServiceReference<ContextAwareService> reference, ServiceInfo serviceInfo) {
+  public void modifiedService(ServiceReference<T> reference, ServiceInfo<T> serviceInfo) {
     // nothing to do
   }
 
   @Override
-  public void removedService(ServiceReference<ContextAwareService> reference, ServiceInfo serviceInfo) {
-    if (log.isDebugEnabled()) {
-      log.debug("Remove service {}", serviceInfo.getService().getClass().getName());
-    }
+  public void removedService(ServiceReference<T> reference, ServiceInfo<T> serviceInfo) {
+    logServiceDebugMessage("Remove service {}", serviceInfo);
     if (rankedServices != null) {
       rankedServices.unbind(serviceInfo, serviceInfo.getServiceProperties());
     }
@@ -89,33 +84,35 @@ class ContextAwareServiceTracker implements ServiceTrackerCustomizer<ContextAwar
     bundleContext.ungetService(reference);
   }
 
-  public Stream<ServiceInfo> resolve(@Nullable Resource resource, @Nullable Filter filter) {
+  public Stream<ServiceInfo<T>> resolve(@Nullable String resourcePath, @Nullable Filter filter) {
     if (rankedServices == null) {
       return Stream.empty();
     }
     return rankedServices.getList().stream()
         .filter(serviceInfo -> serviceInfo.matchesFilter(filter))
-        .filter(serviceInfo -> matchesResource(serviceInfo, resource));
+        .filter(serviceInfo -> serviceInfo.matchesPath(resourcePath));
   }
 
-  private boolean matchesResource(ServiceInfo serviceInfo, Resource resource) {
-    String path = null;
-    if (resource != null) {
-      path = resource.getPath();
-      if (pathPreprocessor != null) {
-        // apply path preprocessor
-        path = pathPreprocessor.apply(path, resource.getResourceResolver());
-      }
-    }
-    return serviceInfo.matches(path);
+  public String getServiceClassName() {
+    return this.serviceClassName;
   }
 
   public long getLastServiceChangeTimestamp() {
     return this.lastServiceChange;
   }
 
-  public Iterable<ServiceInfo> getServiceInfos() {
+  public Iterable<ServiceInfo<T>> getServiceInfos() {
     return rankedServices;
+  }
+
+  private void logServiceDebugMessage(String message, ServiceInfo<T> serviceInfo) {
+    if (!log.isDebugEnabled()) {
+      return;
+    }
+    Object service = serviceInfo.getService();
+    if (service != null) {
+      log.debug(message, service.getClass().getName());
+    }
   }
 
 }

--- a/src/main/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceTracker.java
+++ b/src/main/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceTracker.java
@@ -26,7 +26,6 @@ import org.apache.sling.commons.osgi.RankedServices;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Filter;
 import org.osgi.framework.ServiceReference;
 import org.osgi.util.tracker.ServiceTracker;
 import org.osgi.util.tracker.ServiceTrackerCustomizer;
@@ -84,13 +83,12 @@ class ContextAwareServiceTracker<T extends ContextAwareService> implements Servi
     bundleContext.ungetService(reference);
   }
 
-  public Stream<ServiceInfo<T>> resolve(@Nullable String resourcePath, @Nullable Filter filter) {
+  public Stream<ServiceInfo<T>> resolve(@Nullable String resourcePath) {
     if (rankedServices == null) {
       return Stream.empty();
     }
     return rankedServices.getList().stream()
-        .filter(serviceInfo -> serviceInfo.matchesFilter(filter))
-        .filter(serviceInfo -> serviceInfo.matchesPath(resourcePath));
+        .filter(serviceInfo -> serviceInfo.matches(resourcePath));
   }
 
   public String getServiceClassName() {

--- a/src/main/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceTracker.java
+++ b/src/main/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceTracker.java
@@ -34,12 +34,12 @@ import org.slf4j.LoggerFactory;
 
 import io.wcm.sling.commons.caservice.ContextAwareService;
 
-class ContextAwareServiceTracker<T extends ContextAwareService> implements ServiceTrackerCustomizer<T, ServiceInfo<T>> {
+class ContextAwareServiceTracker<S extends ContextAwareService> implements ServiceTrackerCustomizer<S, ServiceInfo<S>> {
 
   private final String serviceClassName;
   private final BundleContext bundleContext;
-  private final ServiceTracker<T, ServiceInfo<T>> serviceTracker;
-  private volatile RankedServices<ServiceInfo<T>> rankedServices;
+  private final ServiceTracker<S, ServiceInfo<S>> serviceTracker;
+  private volatile RankedServices<ServiceInfo<S>> rankedServices;
   private volatile long lastServiceChange;
 
   private static final Logger log = LoggerFactory.getLogger(ContextAwareServiceTracker.class);
@@ -58,8 +58,8 @@ class ContextAwareServiceTracker<T extends ContextAwareService> implements Servi
   }
 
   @Override
-  public ServiceInfo addingService(ServiceReference<T> reference) {
-    ServiceInfo<T> serviceInfo = new ServiceInfo<>(reference, bundleContext);
+  public ServiceInfo addingService(ServiceReference<S> reference) {
+    ServiceInfo<S> serviceInfo = new ServiceInfo<>(reference, bundleContext);
     logServiceDebugMessage("Add service {}", serviceInfo);
     if (rankedServices != null) {
       rankedServices.bind(serviceInfo, serviceInfo.getServiceProperties());
@@ -69,12 +69,12 @@ class ContextAwareServiceTracker<T extends ContextAwareService> implements Servi
   }
 
   @Override
-  public void modifiedService(ServiceReference<T> reference, ServiceInfo<T> serviceInfo) {
+  public void modifiedService(ServiceReference<S> reference, ServiceInfo<S> serviceInfo) {
     // nothing to do
   }
 
   @Override
-  public void removedService(ServiceReference<T> reference, ServiceInfo<T> serviceInfo) {
+  public void removedService(ServiceReference<S> reference, ServiceInfo<S> serviceInfo) {
     logServiceDebugMessage("Remove service {}", serviceInfo);
     if (rankedServices != null) {
       rankedServices.unbind(serviceInfo, serviceInfo.getServiceProperties());
@@ -83,7 +83,7 @@ class ContextAwareServiceTracker<T extends ContextAwareService> implements Servi
     bundleContext.ungetService(reference);
   }
 
-  public Stream<ServiceInfo<T>> resolve(@Nullable String resourcePath) {
+  public Stream<ServiceInfo<S>> resolve(@Nullable String resourcePath) {
     if (rankedServices == null) {
       return Stream.empty();
     }
@@ -99,11 +99,11 @@ class ContextAwareServiceTracker<T extends ContextAwareService> implements Servi
     return this.lastServiceChange;
   }
 
-  public Iterable<ServiceInfo<T>> getServiceInfos() {
+  public Iterable<ServiceInfo<S>> getServiceInfos() {
     return rankedServices;
   }
 
-  private void logServiceDebugMessage(String message, ServiceInfo<T> serviceInfo) {
+  private void logServiceDebugMessage(String message, ServiceInfo<S> serviceInfo) {
     if (!log.isDebugEnabled()) {
       return;
     }

--- a/src/main/java/io/wcm/sling/commons/caservice/impl/ResolveAllResultImpl.java
+++ b/src/main/java/io/wcm/sling/commons/caservice/impl/ResolveAllResultImpl.java
@@ -27,19 +27,19 @@ import org.jetbrains.annotations.NotNull;
 import io.wcm.sling.commons.caservice.ContextAwareService;
 import io.wcm.sling.commons.caservice.ContextAwareServiceResolver.ResolveAllResult;
 
-class ResolveAllResultImpl<T extends ContextAwareService> implements ResolveAllResult<T> {
+class ResolveAllResultImpl<S extends ContextAwareService> implements ResolveAllResult<S> {
 
-  private final Stream<T> services;
+  private final Stream<S> services;
   private final Supplier<String> combinedKeySupplier;
   private String combinedKey;
 
-  ResolveAllResultImpl(Stream<T> services, Supplier<String> combinedKeySupplier) {
+  ResolveAllResultImpl(Stream<S> services, Supplier<String> combinedKeySupplier) {
     this.services = services;
     this.combinedKeySupplier = combinedKeySupplier;
   }
 
   @Override
-  public @NotNull Stream<T> getServices() {
+  public @NotNull Stream<S> getServices() {
     return services;
   }
 

--- a/src/main/java/io/wcm/sling/commons/caservice/impl/ResolveAllResultImpl.java
+++ b/src/main/java/io/wcm/sling/commons/caservice/impl/ResolveAllResultImpl.java
@@ -30,11 +30,12 @@ import io.wcm.sling.commons.caservice.ContextAwareServiceResolver.ResolveAllResu
 class ResolveAllResultImpl<T extends ContextAwareService> implements ResolveAllResult<T> {
 
   private final Stream<T> services;
-  private final Supplier<String> combinedKey;
+  private final Supplier<String> combinedKeySupplier;
+  private String combinedKey;
 
-  ResolveAllResultImpl(Stream<T> services, Supplier<String> combinedKey) {
+  ResolveAllResultImpl(Stream<T> services, Supplier<String> combinedKeySupplier) {
     this.services = services;
-    this.combinedKey = combinedKey;
+    this.combinedKeySupplier = combinedKeySupplier;
   }
 
   @Override
@@ -44,7 +45,10 @@ class ResolveAllResultImpl<T extends ContextAwareService> implements ResolveAllR
 
   @Override
   public @NotNull String getCombinedKey() {
-    return combinedKey.get();
+    if (combinedKey == null) {
+      combinedKey = combinedKeySupplier.get();
+    }
+    return combinedKey;
   }
 
 }

--- a/src/main/java/io/wcm/sling/commons/caservice/impl/ResolverHelper.java
+++ b/src/main/java/io/wcm/sling/commons/caservice/impl/ResolverHelper.java
@@ -1,0 +1,112 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2022 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.sling.commons.caservice.impl;
+
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.adapter.Adaptable;
+import org.apache.sling.api.resource.Resource;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import com.day.cq.wcm.api.components.ComponentContext;
+import com.day.cq.wcm.commons.WCMUtils;
+
+import io.wcm.sling.commons.caservice.ContextAwareService;
+import io.wcm.sling.commons.caservice.PathPreprocessor;
+
+/**
+ * Helps mapping adaptable to actual resource, and getting resource path respecting a path preprocessor.
+ */
+class ResolverHelper {
+
+  private final PathPreprocessor pathPreprocessor;
+
+  ResolverHelper(@Nullable PathPreprocessor pathPreprocessor) {
+    this.pathPreprocessor = pathPreprocessor;
+  }
+
+  /**
+   * Get resource path from resource represented by Adaptable.
+   * @param adaptable Either a {@link Resource} or a {@link SlingHttpServletRequest} instance.
+   * @return Resource path or null
+   */
+  public @Nullable String getResourcePath(@Nullable Adaptable adaptable) {
+    Resource resource = getResourceFromAdaptable(adaptable);
+    String path = null;
+    if (resource != null) {
+      path = resource.getPath();
+      if (pathPreprocessor != null) {
+        // apply path preprocessor
+        path = pathPreprocessor.apply(path, resource.getResourceResolver());
+      }
+    }
+    return path;
+  }
+
+  private @Nullable Resource getResourceFromAdaptable(@Nullable Adaptable adaptable) {
+    if (adaptable instanceof Resource) {
+      return (Resource)adaptable;
+    }
+    else if (adaptable instanceof SlingHttpServletRequest) {
+      // if request has a current page prefer the page content resource as context resource
+      // because otherwise included resource e.g. from experience fragments lead to wrong contexts
+      SlingHttpServletRequest request = (SlingHttpServletRequest)adaptable;
+      ComponentContext wcmComponentContext = WCMUtils.getComponentContext(request);
+      if (wcmComponentContext != null && wcmComponentContext.getPage() != null) {
+        return wcmComponentContext.getPage().getContentResource();
+      }
+      else {
+        return request.getResource();
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Maps a list of service infos to a list of services, filtering out invalid ones.
+   * @param <T> Service class or interface
+   * @param serviceInfos Service infos
+   * @return Valid services
+   */
+  @SuppressWarnings("null")
+  public <T extends ContextAwareService> Stream<T> getValidServices(Stream<ServiceInfo<T>> serviceInfos) {
+    return serviceInfos
+        .filter(ServiceInfo::isValid)
+        .map(ServiceInfo::getService);
+  }
+
+  /**
+   * Build a timestamp for {@link ResolveAllResultImpl} based on timestamp of service tracker/collection
+   * and the stream of returned services.
+   * @param timestamp Timestamp from service tracker or collection.
+   * @param serviceInfos Service infos
+   * @return Supplier which builds timestamp on demand.
+   */
+  public <T extends ContextAwareService> @NotNull Supplier<String> buildCombinedKey(long timestamp,
+      @NotNull Stream<ServiceInfo<T>> serviceInfos) {
+    return () -> timestamp + "\n"
+        + serviceInfos.map(ServiceInfo::getKey).collect(Collectors.joining("\n~\n"));
+  }
+
+}

--- a/src/main/java/io/wcm/sling/commons/caservice/impl/ResourcePathResolver.java
+++ b/src/main/java/io/wcm/sling/commons/caservice/impl/ResourcePathResolver.java
@@ -19,30 +19,24 @@
  */
 package io.wcm.sling.commons.caservice.impl;
 
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.adapter.Adaptable;
 import org.apache.sling.api.resource.Resource;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import com.day.cq.wcm.api.components.ComponentContext;
 import com.day.cq.wcm.commons.WCMUtils;
 
-import io.wcm.sling.commons.caservice.ContextAwareService;
 import io.wcm.sling.commons.caservice.PathPreprocessor;
 
 /**
  * Helps mapping adaptable to actual resource, and getting resource path respecting a path preprocessor.
  */
-class ResolverHelper {
+class ResourcePathResolver {
 
   private final PathPreprocessor pathPreprocessor;
 
-  ResolverHelper(@Nullable PathPreprocessor pathPreprocessor) {
+  ResourcePathResolver(@Nullable PathPreprocessor pathPreprocessor) {
     this.pathPreprocessor = pathPreprocessor;
   }
 
@@ -51,7 +45,7 @@ class ResolverHelper {
    * @param adaptable Either a {@link Resource} or a {@link SlingHttpServletRequest} instance.
    * @return Resource path or null
    */
-  public @Nullable String getResourcePath(@Nullable Adaptable adaptable) {
+  public @Nullable String get(@Nullable Adaptable adaptable) {
     Resource resource = getResourceFromAdaptable(adaptable);
     String path = null;
     if (resource != null) {
@@ -81,32 +75,6 @@ class ResolverHelper {
       }
     }
     return null;
-  }
-
-  /**
-   * Maps a list of service infos to a list of services, filtering out invalid ones.
-   * @param <T> Service class or interface
-   * @param serviceInfos Service infos
-   * @return Valid services
-   */
-  @SuppressWarnings("null")
-  public <T extends ContextAwareService> Stream<T> getValidServices(Stream<ServiceInfo<T>> serviceInfos) {
-    return serviceInfos
-        .filter(ServiceInfo::isValid)
-        .map(ServiceInfo::getService);
-  }
-
-  /**
-   * Build a timestamp for {@link ResolveAllResultImpl} based on timestamp of service tracker/collection
-   * and the stream of returned services.
-   * @param timestamp Timestamp from service tracker or collection.
-   * @param serviceInfos Service infos
-   * @return Supplier which builds timestamp on demand.
-   */
-  public <T extends ContextAwareService> @NotNull Supplier<String> buildCombinedKey(long timestamp,
-      @NotNull Stream<ServiceInfo<T>> serviceInfos) {
-    return () -> timestamp + "\n"
-        + serviceInfos.map(ServiceInfo::getKey).collect(Collectors.joining("\n~\n"));
   }
 
 }

--- a/src/main/java/io/wcm/sling/commons/caservice/impl/ServiceInfo.java
+++ b/src/main/java/io/wcm/sling/commons/caservice/impl/ServiceInfo.java
@@ -23,7 +23,6 @@ import static io.wcm.sling.commons.caservice.ContextAwareService.PROPERTY_ACCEPT
 import static io.wcm.sling.commons.caservice.ContextAwareService.PROPERTY_CONTEXT_PATH_BLACKLIST_PATTERN;
 import static io.wcm.sling.commons.caservice.ContextAwareService.PROPERTY_CONTEXT_PATH_PATTERN;
 
-import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -36,7 +35,6 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Filter;
 import org.osgi.framework.ServiceReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,7 +50,6 @@ class ServiceInfo<T extends ContextAwareService> {
 
   private final @Nullable T service;
   private final Map<String, Object> servicePropertiesMap;
-  private final Dictionary<String, Object> servicePropertiesDictionary;
   private final Pattern contextPathRegex;
   private final Pattern contextPathBlacklistRegex;
   private final boolean acceptsContextPathEmpty;
@@ -75,7 +72,6 @@ class ServiceInfo<T extends ContextAwareService> {
    */
   ServiceInfo(@NotNull ServiceReference<T> serviceReference, @Nullable T service) {
     this.service = service;
-    this.servicePropertiesDictionary = serviceReference.getProperties();
     this.servicePropertiesMap = propertiesToMap(serviceReference);
     this.contextPathRegex = validateAndParsePattern(serviceReference, service, PROPERTY_CONTEXT_PATH_PATTERN);
     this.contextPathBlacklistRegex = validateAndParsePattern(serviceReference, service, PROPERTY_CONTEXT_PATH_BLACKLIST_PATTERN);
@@ -177,7 +173,7 @@ class ServiceInfo<T extends ContextAwareService> {
    * @param resourcePath Resource path
    * @return true if the implementation matches and the configuration is not invalid.
    */
-  public boolean matchesPath(String resourcePath) {
+  public boolean matches(String resourcePath) {
     if (!valid) {
       return false;
     }
@@ -191,18 +187,6 @@ class ServiceInfo<T extends ContextAwareService> {
       return false;
     }
     return true;
-  }
-
-  /**
-   * Checks if the services matched the given filter.
-   * @param filter OSGi filter. If null it matches always.
-   * @return true if matching
-   */
-  public boolean matchesFilter(@Nullable Filter filter) {
-    if (filter == null) {
-      return true;
-    }
-    return filter.match(servicePropertiesDictionary);
   }
 
   private String buildKey() {

--- a/src/main/java/io/wcm/sling/commons/caservice/impl/ServiceInfo.java
+++ b/src/main/java/io/wcm/sling/commons/caservice/impl/ServiceInfo.java
@@ -44,11 +44,11 @@ import io.wcm.sling.commons.caservice.ContextAwareService;
 /**
  * Extracts metadata of a context-aware service implementation.
  */
-class ServiceInfo<T extends ContextAwareService> {
+class ServiceInfo<S extends ContextAwareService> {
 
   private static final Pattern PATTERN_MATCH_ALL = Pattern.compile(".*");
 
-  private final @Nullable T service;
+  private final @Nullable S service;
   private final Map<String, Object> servicePropertiesMap;
   private final Pattern contextPathRegex;
   private final Pattern contextPathBlacklistRegex;
@@ -62,7 +62,7 @@ class ServiceInfo<T extends ContextAwareService> {
    * @param serviceReference Service reference
    * @param bundleContext Bundle context
    */
-  ServiceInfo(@NotNull ServiceReference<T> serviceReference, @NotNull BundleContext bundleContext) {
+  ServiceInfo(@NotNull ServiceReference<S> serviceReference, @NotNull BundleContext bundleContext) {
     this(serviceReference, validateAndGetService(serviceReference, bundleContext));
   }
 
@@ -70,7 +70,7 @@ class ServiceInfo<T extends ContextAwareService> {
    * @param serviceReference Service reference
    * @param service Service instance
    */
-  ServiceInfo(@NotNull ServiceReference<T> serviceReference, @Nullable T service) {
+  ServiceInfo(@NotNull ServiceReference<S> serviceReference, @Nullable S service) {
     this.service = service;
     this.servicePropertiesMap = propertiesToMap(serviceReference);
     this.contextPathRegex = validateAndParsePattern(serviceReference, service, PROPERTY_CONTEXT_PATH_PATTERN);
@@ -81,11 +81,11 @@ class ServiceInfo<T extends ContextAwareService> {
   }
 
   @SuppressWarnings("unchecked")
-  private static <T extends ContextAwareService> @Nullable T validateAndGetService(
-      @NotNull ServiceReference<T> serviceReference, @NotNull BundleContext bundleContext) {
+  private static <S extends ContextAwareService> @Nullable S validateAndGetService(
+      @NotNull ServiceReference<S> serviceReference, @NotNull BundleContext bundleContext) {
     Object serviceObject = bundleContext.getService(serviceReference);
     if (serviceObject instanceof ContextAwareService) {
-      return (T)serviceObject;
+      return (S)serviceObject;
     }
     if (log.isWarnEnabled()) {
       log.warn("Service implementation {} does not implement the ContextAwareService interface"
@@ -94,7 +94,7 @@ class ServiceInfo<T extends ContextAwareService> {
     return null;
   }
 
-  private static <T extends ContextAwareService> Map<String, Object> propertiesToMap(@NotNull ServiceReference<T> reference) {
+  private static <S extends ContextAwareService> Map<String, Object> propertiesToMap(@NotNull ServiceReference<S> reference) {
     Map<String, Object> props = new HashMap<>();
     for (String propertyName : reference.getPropertyKeys()) {
       props.put(propertyName, reference.getProperty(propertyName));
@@ -102,8 +102,8 @@ class ServiceInfo<T extends ContextAwareService> {
     return props;
   }
 
-  private static <T extends ContextAwareService> Object lookupServicePropertyBundleHeader(
-      @NotNull ServiceReference<T> serviceReference, @NotNull String propertyName) {
+  private static <S extends ContextAwareService> Object lookupServicePropertyBundleHeader(
+      @NotNull ServiceReference<S> serviceReference, @NotNull String propertyName) {
     Object value = serviceReference.getProperty(propertyName);
     if (value == null) {
       value = serviceReference.getBundle().getHeaders().get(propertyName);
@@ -111,8 +111,8 @@ class ServiceInfo<T extends ContextAwareService> {
     return value;
   }
 
-  private static <T extends ContextAwareService> Pattern validateAndParsePattern(
-      @NotNull ServiceReference<T> serviceReference, @Nullable T service, @NotNull String patternPropertyName) {
+  private static <S extends ContextAwareService> Pattern validateAndParsePattern(
+      @NotNull ServiceReference<S> serviceReference, @Nullable S service, @NotNull String patternPropertyName) {
     Object value = lookupServicePropertyBundleHeader(serviceReference, patternPropertyName);
     if (value == null || value instanceof String) {
       String patternString = (String)value;
@@ -149,7 +149,7 @@ class ServiceInfo<T extends ContextAwareService> {
    * Service implementation.
    * @return Service object.
    */
-  public @Nullable T getService() {
+  public @Nullable S getService() {
     return this.service;
   }
 

--- a/src/test/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceCollectionResolverImplTest.java
+++ b/src/test/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceCollectionResolverImplTest.java
@@ -19,32 +19,19 @@
  */
 package io.wcm.sling.commons.caservice.impl;
 
-import static io.wcm.sling.commons.caservice.ContextAwareService.PROPERTY_ACCEPTS_CONTEXT_PATH_EMPTY;
-import static io.wcm.sling.commons.caservice.ContextAwareService.PROPERTY_CONTEXT_PATH_BLACKLIST_PATTERN;
-import static io.wcm.sling.commons.caservice.ContextAwareService.PROPERTY_CONTEXT_PATH_PATTERN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.osgi.framework.Constants.SERVICE_RANKING;
 
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.Dictionary;
-import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.sling.testing.mock.osgi.MapUtil;
-import org.apache.sling.testing.mock.osgi.MockBundle;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.osgi.framework.ServiceObjects;
-import org.osgi.framework.ServiceRegistration;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 import io.wcm.sling.commons.caservice.ContextAwareServiceCollectionResolver;
 import io.wcm.sling.commons.caservice.ContextAwareServiceResolver;
@@ -58,49 +45,27 @@ class ContextAwareServiceCollectionResolverImplTest {
 
   private final AemContext context = new AemContext();
 
+  private TestServices testServices;
   private DummySpi contentImpl;
   private DummySpi contentDamImpl;
   private DummySpi contentSampleImpl;
 
   private ContextAwareServiceResolver contextAwareServiceResolver;
-  private Collection<ServiceObjects<DummySpi>> services = new TreeSet<>(new Comparator<ServiceObjects<DummySpi>>() {
-    @Override
-    public int compare(ServiceObjects<DummySpi> o1, ServiceObjects<DummySpi> o2) {
-      return o2.getServiceReference().compareTo(o1.getServiceReference());
-    }
-  });
 
   @BeforeEach
   void setUp() {
-    contentImpl = registerDummySpi(new DummySpiImpl("/content/*"),
-        PROPERTY_CONTEXT_PATH_PATTERN, "^/content(/.*)?$",
-        SERVICE_RANKING, 100);
-    contentDamImpl = registerDummySpi(new DummySpiImpl("/content/dam/*"),
-        PROPERTY_CONTEXT_PATH_PATTERN, "^/content/dam(/.*)?$",
-        SERVICE_RANKING, 200);
-    contentSampleImpl = registerDummySpi(new DummySpiImpl("/content/sample/*[!=exclude]"),
-        PROPERTY_CONTEXT_PATH_PATTERN, "^/content/sample(/.*)?$",
-        PROPERTY_CONTEXT_PATH_BLACKLIST_PATTERN, "^/content/sample/exclude(/.*)?$",
-        SERVICE_RANKING, 300);
-
-    // add some more services with high ranking but invalid properties - they should never be returned
-    registerDummySpi(new DummySpiImpl("invalid1"),
-        PROPERTY_CONTEXT_PATH_PATTERN, "(",
-        SERVICE_RANKING, 10000);
-    registerDummySpi(new DummySpiImpl("invalid2"),
-        PROPERTY_CONTEXT_PATH_PATTERN, "^/content(/.*)?$",
-        PROPERTY_CONTEXT_PATH_BLACKLIST_PATTERN, ")",
-        SERVICE_RANKING, 20000);
+    testServices = new TestServices(context);
+    contentImpl = testServices.getContentService();
+    contentDamImpl = testServices.getContentDamService();
+    contentSampleImpl = testServices.getContentSampleService();
 
     contextAwareServiceResolver = context.registerInjectActivateService(new ContextAwareServiceResolverImpl());
   }
 
   @Test
   void testWithDefaultImpl() {
-    DummySpi defaultImpl = registerDummySpi(new DummySpiImpl("default"),
-        SERVICE_RANKING, Integer.MIN_VALUE,
-        PROPERTY_ACCEPTS_CONTEXT_PATH_EMPTY, true);
-    ContextAwareServiceCollectionResolver<DummySpi> underTest = contextAwareServiceResolver.getCollectionResolver(services);
+    DummySpi defaultImpl = testServices.addDefaultService();
+    ContextAwareServiceCollectionResolver<DummySpi> underTest = contextAwareServiceResolver.getCollectionResolver(testServices.getServices());
 
     assertSame(contentImpl, underTest.resolve(context.create().resource("/content/test1")));
     assertSame(contentSampleImpl, underTest.resolve(context.create().resource("/content/sample/test1")));
@@ -114,7 +79,7 @@ class ContextAwareServiceCollectionResolverImplTest {
 
   @Test
   void testWithoutDefaultImpl() {
-    ContextAwareServiceCollectionResolver<DummySpi> underTest = contextAwareServiceResolver.getCollectionResolver(services);
+    ContextAwareServiceCollectionResolver<DummySpi> underTest = contextAwareServiceResolver.getCollectionResolver(testServices.getServices());
 
     assertSame(contentImpl, underTest.resolve(context.create().resource("/content/test1")));
     assertSame(contentSampleImpl, underTest.resolve(context.create().resource("/content/sample/test1")));
@@ -130,10 +95,8 @@ class ContextAwareServiceCollectionResolverImplTest {
 
   @Test
   void testWithSlingHttpServletRequest() {
-    DummySpi defaultImpl = registerDummySpi(new DummySpiImpl("default"),
-        SERVICE_RANKING, Integer.MIN_VALUE,
-        PROPERTY_ACCEPTS_CONTEXT_PATH_EMPTY, true);
-    ContextAwareServiceCollectionResolver<DummySpi> underTest = contextAwareServiceResolver.getCollectionResolver(services);
+    DummySpi defaultImpl = testServices.addDefaultService();
+    ContextAwareServiceCollectionResolver<DummySpi> underTest = contextAwareServiceResolver.getCollectionResolver(testServices.getServices());
 
     context.currentResource(context.create().resource("/content/sample/test1"));
     assertSame(contentSampleImpl, underTest.resolve(context.request()));
@@ -148,10 +111,8 @@ class ContextAwareServiceCollectionResolverImplTest {
    */
   @Test
   void testWithSlingHttpServletRequest_ResourceOtherContext() {
-    DummySpi defaultImpl = registerDummySpi(new DummySpiImpl("default"),
-        SERVICE_RANKING, Integer.MIN_VALUE,
-        PROPERTY_ACCEPTS_CONTEXT_PATH_EMPTY, true);
-    ContextAwareServiceCollectionResolver<DummySpi> underTest = contextAwareServiceResolver.getCollectionResolver(services);
+    DummySpi defaultImpl = testServices.addDefaultService();
+    ContextAwareServiceCollectionResolver<DummySpi> underTest = contextAwareServiceResolver.getCollectionResolver(testServices.getServices());
 
     context.currentPage(context.create().page("/content/sample/test1"));
     context.currentResource(context.create().resource("/content/experience-fragments/test1"));
@@ -163,10 +124,9 @@ class ContextAwareServiceCollectionResolverImplTest {
 
   @Test
   void testWithNull() {
-    DummySpi defaultImpl = registerDummySpi(new DummySpiImpl("default"),
-        SERVICE_RANKING, Integer.MIN_VALUE,
-        PROPERTY_ACCEPTS_CONTEXT_PATH_EMPTY, true);
-    ContextAwareServiceCollectionResolver<DummySpi> underTest = contextAwareServiceResolver.getCollectionResolver(services);
+    DummySpi defaultImpl = testServices.addDefaultService();
+
+    ContextAwareServiceCollectionResolver<DummySpi> underTest = contextAwareServiceResolver.getCollectionResolver(testServices.getServices());
 
     assertSame(defaultImpl, underTest.resolve(null));
 
@@ -175,7 +135,7 @@ class ContextAwareServiceCollectionResolverImplTest {
 
   @Test
   void testResolveAllCombindedKey() {
-    ContextAwareServiceCollectionResolver<DummySpi> underTest = contextAwareServiceResolver.getCollectionResolver(services);
+    ContextAwareServiceCollectionResolver<DummySpi> underTest = contextAwareServiceResolver.getCollectionResolver(testServices.getServices());
 
     ResolveAllResult result1 = underTest.resolveAll(context.create().resource("/content/dam/test1"));
     ResolveAllResult result2 = underTest.resolveAll(context.create().resource("/content/dam/test2"));
@@ -186,14 +146,9 @@ class ContextAwareServiceCollectionResolverImplTest {
   }
 
   @Test
-  @SuppressWarnings("null")
   void testWithBundleHeader() {
-    // service gets path pattern from bundle header instead of service property
-    ((MockBundle)context.bundleContext().getBundle()).setHeaders(ImmutableMap.of(
-        PROPERTY_CONTEXT_PATH_PATTERN, "^/content/dam(/.*)?$"));
-    DummySpi contentDamImplWithBundleHeader = registerDummySpi(new DummySpiImpl("/content/dam (bundle header)"),
-        SERVICE_RANKING, 1000);
-    ContextAwareServiceCollectionResolver<DummySpi> underTest = contextAwareServiceResolver.getCollectionResolver(services);
+    DummySpi contentDamImplWithBundleHeader = testServices.addContentDamImplWithBundleHeader();
+    ContextAwareServiceCollectionResolver<DummySpi> underTest = contextAwareServiceResolver.getCollectionResolver(testServices.getServices());
 
     assertSame(contentImpl, underTest.resolve(context.create().resource("/content/test1")));
     assertSame(contentSampleImpl, underTest.resolve(context.create().resource("/content/sample/test1")));
@@ -209,7 +164,7 @@ class ContextAwareServiceCollectionResolverImplTest {
   void testWithPathPreProcessor() {
     context.registerService(PathPreprocessor.class, (path, resourceResolver) -> StringUtils.removeStart(path, "/pathprefix"));
     contextAwareServiceResolver = context.registerInjectActivateService(new ContextAwareServiceResolverImpl());
-    ContextAwareServiceCollectionResolver<DummySpi> underTest = contextAwareServiceResolver.getCollectionResolver(services);
+    ContextAwareServiceCollectionResolver<DummySpi> underTest = contextAwareServiceResolver.getCollectionResolver(testServices.getServices());
 
     assertSame(contentImpl, underTest.resolve(context.create().resource("/pathprefix/content/test1")));
     assertSame(contentSampleImpl, underTest.resolve(context.create().resource("/pathprefix/content/sample/test1")));
@@ -219,14 +174,6 @@ class ContextAwareServiceCollectionResolverImplTest {
 
     assertEquals(ImmutableList.of(contentDamImpl, contentImpl),
         underTest.resolveAll(context.create().resource("/pathprefix/content/dam/test2")).getServices().collect(Collectors.toList()));
-  }
-
-  @SuppressWarnings("null")
-  private DummySpi registerDummySpi(DummySpi service, Object... properties) {
-    Dictionary<String, Object> serviceProperties = MapUtil.toDictionary(properties);
-    ServiceRegistration<DummySpi> serviceRegistration = context.bundleContext().registerService(DummySpi.class, service, serviceProperties);
-    services.add(new MockServiceObjects<DummySpi>(serviceRegistration.getReference(), service));
-    return service;
   }
 
 }

--- a/src/test/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceCollectionResolverImplTest.java
+++ b/src/test/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceCollectionResolverImplTest.java
@@ -1,0 +1,232 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2022 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.sling.commons.caservice.impl;
+
+import static io.wcm.sling.commons.caservice.ContextAwareService.PROPERTY_ACCEPTS_CONTEXT_PATH_EMPTY;
+import static io.wcm.sling.commons.caservice.ContextAwareService.PROPERTY_CONTEXT_PATH_BLACKLIST_PATTERN;
+import static io.wcm.sling.commons.caservice.ContextAwareService.PROPERTY_CONTEXT_PATH_PATTERN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.osgi.framework.Constants.SERVICE_RANKING;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Dictionary;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.testing.mock.osgi.MapUtil;
+import org.apache.sling.testing.mock.osgi.MockBundle;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.osgi.framework.ServiceObjects;
+import org.osgi.framework.ServiceRegistration;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import io.wcm.sling.commons.caservice.ContextAwareServiceCollectionResolver;
+import io.wcm.sling.commons.caservice.ContextAwareServiceResolver;
+import io.wcm.sling.commons.caservice.ContextAwareServiceResolver.ResolveAllResult;
+import io.wcm.sling.commons.caservice.PathPreprocessor;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+
+@ExtendWith(AemContextExtension.class)
+class ContextAwareServiceCollectionResolverImplTest {
+
+  private final AemContext context = new AemContext();
+
+  private DummySpi contentImpl;
+  private DummySpi contentDamImpl;
+  private DummySpi contentSampleImpl;
+
+  private ContextAwareServiceResolver contextAwareServiceResolver;
+  private Collection<ServiceObjects<DummySpi>> services = new TreeSet<>(new Comparator<ServiceObjects<DummySpi>>() {
+    @Override
+    public int compare(ServiceObjects<DummySpi> o1, ServiceObjects<DummySpi> o2) {
+      return o2.getServiceReference().compareTo(o1.getServiceReference());
+    }
+  });
+
+  @BeforeEach
+  void setUp() {
+    contentImpl = registerDummySpi(new DummySpiImpl("/content/*"),
+        PROPERTY_CONTEXT_PATH_PATTERN, "^/content(/.*)?$",
+        SERVICE_RANKING, 100);
+    contentDamImpl = registerDummySpi(new DummySpiImpl("/content/dam/*"),
+        PROPERTY_CONTEXT_PATH_PATTERN, "^/content/dam(/.*)?$",
+        SERVICE_RANKING, 200);
+    contentSampleImpl = registerDummySpi(new DummySpiImpl("/content/sample/*[!=exclude]"),
+        PROPERTY_CONTEXT_PATH_PATTERN, "^/content/sample(/.*)?$",
+        PROPERTY_CONTEXT_PATH_BLACKLIST_PATTERN, "^/content/sample/exclude(/.*)?$",
+        SERVICE_RANKING, 300);
+
+    // add some more services with high ranking but invalid properties - they should never be returned
+    registerDummySpi(new DummySpiImpl("invalid1"),
+        PROPERTY_CONTEXT_PATH_PATTERN, "(",
+        SERVICE_RANKING, 10000);
+    registerDummySpi(new DummySpiImpl("invalid2"),
+        PROPERTY_CONTEXT_PATH_PATTERN, "^/content(/.*)?$",
+        PROPERTY_CONTEXT_PATH_BLACKLIST_PATTERN, ")",
+        SERVICE_RANKING, 20000);
+
+    contextAwareServiceResolver = context.registerInjectActivateService(new ContextAwareServiceResolverImpl());
+  }
+
+  @Test
+  void testWithDefaultImpl() {
+    DummySpi defaultImpl = registerDummySpi(new DummySpiImpl("default"),
+        SERVICE_RANKING, Integer.MIN_VALUE,
+        PROPERTY_ACCEPTS_CONTEXT_PATH_EMPTY, true);
+    ContextAwareServiceCollectionResolver<DummySpi> underTest = contextAwareServiceResolver.getCollectionResolver(services);
+
+    assertSame(contentImpl, underTest.resolve(context.create().resource("/content/test1")));
+    assertSame(contentSampleImpl, underTest.resolve(context.create().resource("/content/sample/test1")));
+    assertSame(contentImpl, underTest.resolve(context.create().resource("/content/sample/exclude/test1")));
+    assertSame(contentDamImpl, underTest.resolve(context.create().resource("/content/dam/test1")));
+    assertSame(defaultImpl, underTest.resolve(context.create().resource("/etc/test1")));
+
+    assertEquals(ImmutableList.of(contentDamImpl, contentImpl, defaultImpl),
+        underTest.resolveAll(context.create().resource("/content/dam/test2")).getServices().collect(Collectors.toList()));
+  }
+
+  @Test
+  void testWithoutDefaultImpl() {
+    ContextAwareServiceCollectionResolver<DummySpi> underTest = contextAwareServiceResolver.getCollectionResolver(services);
+
+    assertSame(contentImpl, underTest.resolve(context.create().resource("/content/test1")));
+    assertSame(contentSampleImpl, underTest.resolve(context.create().resource("/content/sample/test1")));
+    assertSame(contentImpl, underTest.resolve(context.create().resource("/content/sample/exclude/test1")));
+    assertSame(contentDamImpl, underTest.resolve(context.create().resource("/content/dam/test1")));
+    assertNull(underTest.resolve(context.create().resource("/etc/test1")));
+
+    assertEquals(ImmutableList.of(contentDamImpl, contentImpl),
+        underTest.resolveAll(context.create().resource("/content/dam/test2")).getServices().collect(Collectors.toList()));
+    assertEquals(ImmutableList.of(contentSampleImpl, contentImpl),
+        underTest.resolveAll(context.create().resource("/content/sample/test2")).getServices().collect(Collectors.toList()));
+  }
+
+  @Test
+  void testWithSlingHttpServletRequest() {
+    DummySpi defaultImpl = registerDummySpi(new DummySpiImpl("default"),
+        SERVICE_RANKING, Integer.MIN_VALUE,
+        PROPERTY_ACCEPTS_CONTEXT_PATH_EMPTY, true);
+    ContextAwareServiceCollectionResolver<DummySpi> underTest = contextAwareServiceResolver.getCollectionResolver(services);
+
+    context.currentResource(context.create().resource("/content/sample/test1"));
+    assertSame(contentSampleImpl, underTest.resolve(context.request()));
+
+    assertEquals(ImmutableList.of(contentSampleImpl, contentImpl, defaultImpl),
+        underTest.resolveAll(context.request()).getServices().collect(Collectors.toList()));
+  }
+
+  /**
+   * Simulate an experience fragment resource included in a page.
+   * Context-aware service resolver should take the current page as context to resolve, not the current resource.
+   */
+  @Test
+  void testWithSlingHttpServletRequest_ResourceOtherContext() {
+    DummySpi defaultImpl = registerDummySpi(new DummySpiImpl("default"),
+        SERVICE_RANKING, Integer.MIN_VALUE,
+        PROPERTY_ACCEPTS_CONTEXT_PATH_EMPTY, true);
+    ContextAwareServiceCollectionResolver<DummySpi> underTest = contextAwareServiceResolver.getCollectionResolver(services);
+
+    context.currentPage(context.create().page("/content/sample/test1"));
+    context.currentResource(context.create().resource("/content/experience-fragments/test1"));
+    assertSame(contentSampleImpl, underTest.resolve(context.request()));
+
+    assertEquals(ImmutableList.of(contentSampleImpl, contentImpl, defaultImpl),
+        underTest.resolveAll(context.request()).getServices().collect(Collectors.toList()));
+  }
+
+  @Test
+  void testWithNull() {
+    DummySpi defaultImpl = registerDummySpi(new DummySpiImpl("default"),
+        SERVICE_RANKING, Integer.MIN_VALUE,
+        PROPERTY_ACCEPTS_CONTEXT_PATH_EMPTY, true);
+    ContextAwareServiceCollectionResolver<DummySpi> underTest = contextAwareServiceResolver.getCollectionResolver(services);
+
+    assertSame(defaultImpl, underTest.resolve(null));
+
+    assertEquals(ImmutableList.of(defaultImpl), underTest.resolveAll(null).getServices().collect(Collectors.toList()));
+  }
+
+  @Test
+  void testResolveAllCombindedKey() {
+    ContextAwareServiceCollectionResolver<DummySpi> underTest = contextAwareServiceResolver.getCollectionResolver(services);
+
+    ResolveAllResult result1 = underTest.resolveAll(context.create().resource("/content/dam/test1"));
+    ResolveAllResult result2 = underTest.resolveAll(context.create().resource("/content/dam/test2"));
+    ResolveAllResult result3 = underTest.resolveAll(context.create().resource("/content/sample/test3"));
+
+    assertEquals(result1.getCombinedKey(), result2.getCombinedKey());
+    assertNotEquals(result1.getCombinedKey(), result3.getCombinedKey());
+  }
+
+  @Test
+  @SuppressWarnings("null")
+  void testWithBundleHeader() {
+    // service gets path pattern from bundle header instead of service property
+    ((MockBundle)context.bundleContext().getBundle()).setHeaders(ImmutableMap.of(
+        PROPERTY_CONTEXT_PATH_PATTERN, "^/content/dam(/.*)?$"));
+    DummySpi contentDamImplWithBundleHeader = registerDummySpi(new DummySpiImpl("/content/dam (bundle header)"),
+        SERVICE_RANKING, 1000);
+    ContextAwareServiceCollectionResolver<DummySpi> underTest = contextAwareServiceResolver.getCollectionResolver(services);
+
+    assertSame(contentImpl, underTest.resolve(context.create().resource("/content/test1")));
+    assertSame(contentSampleImpl, underTest.resolve(context.create().resource("/content/sample/test1")));
+    assertSame(contentImpl, underTest.resolve(context.create().resource("/content/sample/exclude/test1")));
+    assertSame(contentDamImplWithBundleHeader, underTest.resolve(context.create().resource("/content/dam/test1")));
+    assertNull(underTest.resolve(context.create().resource("/etc/test1")));
+
+    assertEquals(ImmutableList.of(contentDamImplWithBundleHeader, contentDamImpl, contentImpl),
+        underTest.resolveAll(context.create().resource("/content/dam/test2")).getServices().collect(Collectors.toList()));
+  }
+
+  @Test
+  void testWithPathPreProcessor() {
+    context.registerService(PathPreprocessor.class, (path, resourceResolver) -> StringUtils.removeStart(path, "/pathprefix"));
+    contextAwareServiceResolver = context.registerInjectActivateService(new ContextAwareServiceResolverImpl());
+    ContextAwareServiceCollectionResolver<DummySpi> underTest = contextAwareServiceResolver.getCollectionResolver(services);
+
+    assertSame(contentImpl, underTest.resolve(context.create().resource("/pathprefix/content/test1")));
+    assertSame(contentSampleImpl, underTest.resolve(context.create().resource("/pathprefix/content/sample/test1")));
+    assertSame(contentImpl, underTest.resolve(context.create().resource("/pathprefix/content/sample/exclude/test1")));
+    assertSame(contentDamImpl, underTest.resolve(context.create().resource("/pathprefix/content/dam/test1")));
+    assertNull(underTest.resolve(context.create().resource("/pathprefix/etc/test1")));
+
+    assertEquals(ImmutableList.of(contentDamImpl, contentImpl),
+        underTest.resolveAll(context.create().resource("/pathprefix/content/dam/test2")).getServices().collect(Collectors.toList()));
+  }
+
+  @SuppressWarnings("null")
+  private DummySpi registerDummySpi(DummySpi service, Object... properties) {
+    Dictionary<String, Object> serviceProperties = MapUtil.toDictionary(properties);
+    ServiceRegistration<DummySpi> serviceRegistration = context.bundleContext().registerService(DummySpi.class, service, serviceProperties);
+    services.add(new MockServiceObjects<DummySpi>(serviceRegistration.getReference(), service));
+    return service;
+  }
+
+}

--- a/src/test/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceCollectionResolverImplTest.java
+++ b/src/test/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceCollectionResolverImplTest.java
@@ -40,6 +40,9 @@ import io.wcm.sling.commons.caservice.PathPreprocessor;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
+/**
+ * Test resolving context-aware services using service collection against the {@link TestServices}.
+ */
 @ExtendWith(AemContextExtension.class)
 class ContextAwareServiceCollectionResolverImplTest {
 

--- a/src/test/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceCollectionResolverImplTest.java
+++ b/src/test/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceCollectionResolverImplTest.java
@@ -76,7 +76,7 @@ class ContextAwareServiceCollectionResolverImplTest {
     assertSame(defaultImpl, underTest.resolve(context.create().resource("/etc/test1")));
 
     assertEquals(ImmutableList.of(contentDamImpl, contentImpl, defaultImpl),
-        underTest.resolveAll(context.create().resource("/content/dam/test2")));
+        underTest.resolveAll(context.create().resource("/content/dam/test2")).collect(Collectors.toList()));
   }
 
   @Test
@@ -94,7 +94,7 @@ class ContextAwareServiceCollectionResolverImplTest {
 
     assertEquals(ImmutableList.of(contentDamImpl, contentImpl, defaultImpl),
         underTest.resolveAllDecorated(context.create().resource("/content/dam/test2"))
-            .stream().map(DummySpiDecorator::getService).collect(Collectors.toList()));
+            .map(DummySpiDecorator::getService).collect(Collectors.toList()));
   }
 
   @Test
@@ -109,9 +109,9 @@ class ContextAwareServiceCollectionResolverImplTest {
     assertNull(underTest.resolve(context.create().resource("/etc/test1")));
 
     assertEquals(ImmutableList.of(contentDamImpl, contentImpl),
-        underTest.resolveAll(context.create().resource("/content/dam/test2")));
+        underTest.resolveAll(context.create().resource("/content/dam/test2")).collect(Collectors.toList()));
     assertEquals(ImmutableList.of(contentSampleImpl, contentImpl),
-        underTest.resolveAll(context.create().resource("/content/sample/test2")));
+        underTest.resolveAll(context.create().resource("/content/sample/test2")).collect(Collectors.toList()));
   }
 
   @Test
@@ -124,7 +124,7 @@ class ContextAwareServiceCollectionResolverImplTest {
     assertSame(contentSampleImpl, underTest.resolve(context.request()));
 
     assertEquals(ImmutableList.of(contentSampleImpl, contentImpl, defaultImpl),
-        underTest.resolveAll(context.request()));
+        underTest.resolveAll(context.request()).collect(Collectors.toList()));
   }
 
   /**
@@ -142,7 +142,7 @@ class ContextAwareServiceCollectionResolverImplTest {
     assertSame(contentSampleImpl, underTest.resolve(context.request()));
 
     assertEquals(ImmutableList.of(contentSampleImpl, contentImpl, defaultImpl),
-        underTest.resolveAll(context.request()));
+        underTest.resolveAll(context.request()).collect(Collectors.toList()));
   }
 
   @Test
@@ -154,7 +154,7 @@ class ContextAwareServiceCollectionResolverImplTest {
 
     assertSame(defaultImpl, underTest.resolve(null));
 
-    assertEquals(ImmutableList.of(defaultImpl), underTest.resolveAll(null));
+    assertEquals(ImmutableList.of(defaultImpl), underTest.resolveAll(null).collect(Collectors.toList()));
   }
 
   @Test
@@ -170,7 +170,7 @@ class ContextAwareServiceCollectionResolverImplTest {
     assertNull(underTest.resolve(context.create().resource("/etc/test1")));
 
     assertEquals(ImmutableList.of(contentDamImplWithBundleHeader, contentDamImpl, contentImpl),
-        underTest.resolveAll(context.create().resource("/content/dam/test2")));
+        underTest.resolveAll(context.create().resource("/content/dam/test2")).collect(Collectors.toList()));
   }
 
   @Test
@@ -187,7 +187,7 @@ class ContextAwareServiceCollectionResolverImplTest {
     assertNull(underTest.resolve(context.create().resource("/pathprefix/etc/test1")));
 
     assertEquals(ImmutableList.of(contentDamImpl, contentImpl),
-        underTest.resolveAll(context.create().resource("/pathprefix/content/dam/test2")));
+        underTest.resolveAll(context.create().resource("/pathprefix/content/dam/test2")).collect(Collectors.toList()));
   }
 
 }

--- a/src/test/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceInventoryPrinterTest.java
+++ b/src/test/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceInventoryPrinterTest.java
@@ -37,6 +37,9 @@ import io.wcm.sling.commons.caservice.ContextAwareServiceResolver;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
+/**
+ * Test inventory printer.
+ */
 @ExtendWith(AemContextExtension.class)
 class ContextAwareServiceInventoryPrinterTest {
 

--- a/src/test/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceInventoryPrinterTest.java
+++ b/src/test/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceInventoryPrinterTest.java
@@ -1,0 +1,85 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2022 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.sling.commons.caservice.impl;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.felix.inventory.Format;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.wcm.sling.commons.caservice.ContextAwareServiceResolver;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+
+@ExtendWith(AemContextExtension.class)
+class ContextAwareServiceInventoryPrinterTest {
+
+  private final AemContext context = new AemContext();
+  private ContextAwareServiceResolver contextAwareServiceResolver;
+  private ContextAwareServiceInventoryPrinter underTest;
+
+  @BeforeEach
+  protected void setUp() {
+    // register test services
+    new TestServices(context);
+    contextAwareServiceResolver = context.registerInjectActivateService(new ContextAwareServiceResolverImpl());
+    underTest = context.registerInjectActivateService(ContextAwareServiceInventoryPrinter.class);
+  }
+
+  @Test
+  void testNoServiceTracker() throws IOException {
+    String result = getResultFromInventoryPrinter(Format.TEXT);
+    assertTrue(StringUtils.contains(result, "No context-aware services found."));
+  }
+
+  @Test
+  void testWithServiceTracker() throws IOException {
+    // make dummy call to have a service tracker registered
+    contextAwareServiceResolver.resolve(DummySpi.class, null);
+
+    String result = getResultFromInventoryPrinter(Format.TEXT);
+    assertTrue(StringUtils.contains(result, DummySpi.class.getName()));
+  }
+
+  @Test
+  void testNonText() throws IOException {
+    String result = getResultFromInventoryPrinter(Format.HTML);
+    assertTrue(StringUtils.isEmpty(result));
+  }
+
+  private String getResultFromInventoryPrinter(Format format) throws IOException {
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    PrintWriter pw = new PrintWriter(bos);
+    underTest.print(pw, format, false);
+    pw.flush();
+
+    return IOUtils.toString(bos.toByteArray(), StandardCharsets.UTF_8.name());
+  }
+
+}

--- a/src/test/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceResolverImplTest.java
+++ b/src/test/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceResolverImplTest.java
@@ -30,7 +30,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.osgi.framework.InvalidSyntaxException;
 
 import com.google.common.collect.ImmutableList;
 
@@ -45,8 +44,6 @@ import io.wcm.testing.mock.aem.junit5.AemContextExtension;
  */
 @ExtendWith(AemContextExtension.class)
 class ContextAwareServiceResolverImplTest {
-
-  private static final String CUSTOM_PROPERTY = "myprop1";
 
   private final AemContext context = new AemContext();
 
@@ -168,21 +165,6 @@ class ContextAwareServiceResolverImplTest {
 
     assertEquals(ImmutableList.of(contentDamImpl, contentImpl),
         underTest.resolveAll(DummySpi.class, context.create().resource("/pathprefix/content/dam/test2")).getServices().collect(Collectors.toList()));
-  }
-
-  @Test
-  void testWithFilter() throws InvalidSyntaxException {
-    String filter = "(!(" + CUSTOM_PROPERTY + "=s3))";
-    assertSame(contentImpl, underTest.resolve(DummySpi.class, context.create().resource("/content/test1"), filter));
-    assertSame(contentImpl, underTest.resolve(DummySpi.class, context.create().resource("/content/sample/test1"), filter));
-    assertSame(contentImpl, underTest.resolve(DummySpi.class, context.create().resource("/content/sample/exclude/test1"), filter));
-    assertSame(contentDamImpl, underTest.resolve(DummySpi.class, context.create().resource("/content/dam/test1"), filter));
-    assertNull(underTest.resolve(DummySpi.class, context.create().resource("/etc/test1"), filter));
-
-    assertEquals(ImmutableList.of(contentDamImpl, contentImpl),
-        underTest.resolveAll(DummySpi.class, context.create().resource("/content/dam/test2"), filter).getServices().collect(Collectors.toList()));
-    assertEquals(ImmutableList.of(contentImpl),
-        underTest.resolveAll(DummySpi.class, context.create().resource("/content/sample/test2"), filter).getServices().collect(Collectors.toList()));
   }
 
 }

--- a/src/test/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceResolverImplTest.java
+++ b/src/test/java/io/wcm/sling/commons/caservice/impl/ContextAwareServiceResolverImplTest.java
@@ -40,6 +40,9 @@ import io.wcm.sling.commons.caservice.PathPreprocessor;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
+/**
+ * Test resolving context-aware services using service tracker against the {@link TestServices}.
+ */
 @ExtendWith(AemContextExtension.class)
 class ContextAwareServiceResolverImplTest {
 

--- a/src/test/java/io/wcm/sling/commons/caservice/impl/DummySpiDecorator.java
+++ b/src/test/java/io/wcm/sling/commons/caservice/impl/DummySpiDecorator.java
@@ -19,13 +19,13 @@
  */
 package io.wcm.sling.commons.caservice.impl;
 
-import org.osgi.framework.ServiceObjects;
+import org.osgi.service.component.ComponentServiceObjects;
 
 class DummySpiDecorator {
 
   private final DummySpi service;
 
-  DummySpiDecorator(ServiceObjects<DummySpi> serviceObjects) {
+  DummySpiDecorator(ComponentServiceObjects<DummySpi> serviceObjects) {
     this.service = serviceObjects.getService();
   }
 

--- a/src/test/java/io/wcm/sling/commons/caservice/impl/DummySpiDecorator.java
+++ b/src/test/java/io/wcm/sling/commons/caservice/impl/DummySpiDecorator.java
@@ -1,0 +1,36 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2022 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.sling.commons.caservice.impl;
+
+import org.osgi.framework.ServiceObjects;
+
+class DummySpiDecorator {
+
+  private final DummySpi service;
+
+  DummySpiDecorator(ServiceObjects<DummySpi> serviceObjects) {
+    this.service = serviceObjects.getService();
+  }
+
+  DummySpi getService() {
+    return this.service;
+  }
+
+}

--- a/src/test/java/io/wcm/sling/commons/caservice/impl/MockComponentServiceObjects.java
+++ b/src/test/java/io/wcm/sling/commons/caservice/impl/MockComponentServiceObjects.java
@@ -19,15 +19,15 @@
  */
 package io.wcm.sling.commons.caservice.impl;
 
-import org.osgi.framework.ServiceObjects;
 import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.ComponentServiceObjects;
 
-class MockServiceObjects<S> implements ServiceObjects<S> {
+class MockComponentServiceObjects<S> implements ComponentServiceObjects<S> {
 
   private final ServiceReference<S> serviceReference;
   private final S service;
 
-  MockServiceObjects(ServiceReference<S> serviceReference, S service) {
+  MockComponentServiceObjects(ServiceReference<S> serviceReference, S service) {
     this.serviceReference = serviceReference;
     this.service = service;
   }

--- a/src/test/java/io/wcm/sling/commons/caservice/impl/MockServiceObjects.java
+++ b/src/test/java/io/wcm/sling/commons/caservice/impl/MockServiceObjects.java
@@ -2,7 +2,7 @@
  * #%L
  * wcm.io
  * %%
- * Copyright (C) 2017 wcm.io
+ * Copyright (C) 2022 wcm.io
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,17 +19,32 @@
  */
 package io.wcm.sling.commons.caservice.impl;
 
-class DummySpiImpl implements DummySpi {
+import org.osgi.framework.ServiceObjects;
+import org.osgi.framework.ServiceReference;
 
-  private final String info;
+class MockServiceObjects<T> implements ServiceObjects<T> {
 
-  DummySpiImpl(String info) {
-    this.info = info;
+  private final ServiceReference<T> serviceReference;
+  private final T service;
+
+  MockServiceObjects(ServiceReference<T> serviceReference, T service) {
+    this.serviceReference = serviceReference;
+    this.service = service;
   }
 
   @Override
-  public String toString() {
-    return info;
+  public ServiceReference<T> getServiceReference() {
+    return serviceReference;
+  }
+
+  @Override
+  public T getService() {
+    return service;
+  }
+
+  @Override
+  public void ungetService(T svc) {
+    // ignore
   }
 
 }

--- a/src/test/java/io/wcm/sling/commons/caservice/impl/MockServiceObjects.java
+++ b/src/test/java/io/wcm/sling/commons/caservice/impl/MockServiceObjects.java
@@ -22,28 +22,28 @@ package io.wcm.sling.commons.caservice.impl;
 import org.osgi.framework.ServiceObjects;
 import org.osgi.framework.ServiceReference;
 
-class MockServiceObjects<T> implements ServiceObjects<T> {
+class MockServiceObjects<S> implements ServiceObjects<S> {
 
-  private final ServiceReference<T> serviceReference;
-  private final T service;
+  private final ServiceReference<S> serviceReference;
+  private final S service;
 
-  MockServiceObjects(ServiceReference<T> serviceReference, T service) {
+  MockServiceObjects(ServiceReference<S> serviceReference, S service) {
     this.serviceReference = serviceReference;
     this.service = service;
   }
 
   @Override
-  public ServiceReference<T> getServiceReference() {
+  public ServiceReference<S> getServiceReference() {
     return serviceReference;
   }
 
   @Override
-  public T getService() {
+  public S getService() {
     return service;
   }
 
   @Override
-  public void ungetService(T svc) {
+  public void ungetService(S svc) {
     // ignore
   }
 

--- a/src/test/java/io/wcm/sling/commons/caservice/impl/TestServices.java
+++ b/src/test/java/io/wcm/sling/commons/caservice/impl/TestServices.java
@@ -1,0 +1,127 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2022 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.sling.commons.caservice.impl;
+
+import static io.wcm.sling.commons.caservice.ContextAwareService.PROPERTY_ACCEPTS_CONTEXT_PATH_EMPTY;
+import static io.wcm.sling.commons.caservice.ContextAwareService.PROPERTY_CONTEXT_PATH_BLACKLIST_PATTERN;
+import static io.wcm.sling.commons.caservice.ContextAwareService.PROPERTY_CONTEXT_PATH_PATTERN;
+import static org.osgi.framework.Constants.SERVICE_RANKING;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Dictionary;
+import java.util.TreeSet;
+
+import org.apache.sling.testing.mock.osgi.MapUtil;
+import org.apache.sling.testing.mock.osgi.MockBundle;
+import org.osgi.framework.ServiceObjects;
+import org.osgi.framework.ServiceRegistration;
+
+import com.google.common.collect.ImmutableMap;
+
+import io.wcm.testing.mock.aem.junit5.AemContext;
+
+/**
+ * Test services for testing context-aware services implementation.
+ */
+class TestServices {
+
+  private static final String CUSTOM_PROPERTY = "myprop1";
+
+  private final AemContext context;
+
+  private final DummySpi contentService;
+  private final DummySpi contentDamService;
+  private final DummySpi contentSampleService;
+
+  private final Collection<ServiceObjects<DummySpi>> services = new TreeSet<>(new Comparator<ServiceObjects<DummySpi>>() {
+    @Override
+    public int compare(ServiceObjects<DummySpi> o1, ServiceObjects<DummySpi> o2) {
+      return o2.getServiceReference().compareTo(o1.getServiceReference());
+    }
+  });
+
+  TestServices(AemContext context) {
+    this.context = context;
+
+    this.contentService = registerDummySpi(new DummySpiImpl("/content/*"),
+        PROPERTY_CONTEXT_PATH_PATTERN, "^/content(/.*)?$",
+        CUSTOM_PROPERTY, "s1",
+        SERVICE_RANKING, 100);
+    this.contentDamService = registerDummySpi(new DummySpiImpl("/content/dam/*"),
+        PROPERTY_CONTEXT_PATH_PATTERN, "^/content/dam(/.*)?$",
+        CUSTOM_PROPERTY, "s2",
+        SERVICE_RANKING, 200);
+    this.contentSampleService = registerDummySpi(new DummySpiImpl("/content/sample/*[!=exclude]"),
+        PROPERTY_CONTEXT_PATH_PATTERN, "^/content/sample(/.*)?$",
+        PROPERTY_CONTEXT_PATH_BLACKLIST_PATTERN, "^/content/sample/exclude(/.*)?$",
+        CUSTOM_PROPERTY, "s3",
+        SERVICE_RANKING, 300);
+
+    // add some more services with high ranking but invalid properties - they should never be returned
+    registerDummySpi(new DummySpiImpl("invalid1"),
+        PROPERTY_CONTEXT_PATH_PATTERN, "(",
+        SERVICE_RANKING, 10000);
+    registerDummySpi(new DummySpiImpl("invalid2"),
+        PROPERTY_CONTEXT_PATH_PATTERN, "^/content(/.*)?$",
+        PROPERTY_CONTEXT_PATH_BLACKLIST_PATTERN, ")",
+        SERVICE_RANKING, 20000);
+  }
+
+  Collection<ServiceObjects<DummySpi>> getServices() {
+    return this.services;
+  }
+
+  DummySpi getContentService() {
+    return this.contentService;
+  }
+
+  DummySpi getContentDamService() {
+    return this.contentDamService;
+  }
+
+  DummySpi getContentSampleService() {
+    return this.contentSampleService;
+  }
+
+  DummySpi addDefaultService() {
+    return registerDummySpi(new DummySpiImpl("default"),
+        SERVICE_RANKING, Integer.MIN_VALUE,
+        PROPERTY_ACCEPTS_CONTEXT_PATH_EMPTY, true);
+  }
+
+  @SuppressWarnings("null")
+  DummySpi addContentDamImplWithBundleHeader() {
+    // service gets path pattern from bundle header instead of service property
+    ((MockBundle)context.bundleContext().getBundle()).setHeaders(ImmutableMap.of(
+        PROPERTY_CONTEXT_PATH_PATTERN, "^/content/dam(/.*)?$"));
+    return registerDummySpi(new DummySpiImpl("/content/dam (bundle header)"),
+        SERVICE_RANKING, 1000);
+  }
+
+  @SuppressWarnings("null")
+  private DummySpi registerDummySpi(DummySpi service, Object... properties) {
+    Dictionary<String, Object> serviceProperties = MapUtil.toDictionary(properties);
+    ServiceRegistration<DummySpi> serviceRegistration = context.bundleContext().registerService(DummySpi.class, service, serviceProperties);
+    services.add(new MockServiceObjects<DummySpi>(serviceRegistration.getReference(), service));
+    return service;
+  }
+
+}

--- a/src/test/java/io/wcm/sling/commons/caservice/impl/TestServices.java
+++ b/src/test/java/io/wcm/sling/commons/caservice/impl/TestServices.java
@@ -59,22 +59,22 @@ class TestServices {
   TestServices(AemContext context) {
     this.context = context;
 
-    this.contentService = registerDummySpi(new DummySpiImpl("/content/*"),
+    this.contentService = register(new DummySpiImpl("/content/*"),
         PROPERTY_CONTEXT_PATH_PATTERN, "^/content(/.*)?$",
         SERVICE_RANKING, 100);
-    this.contentDamService = registerDummySpi(new DummySpiImpl("/content/dam/*"),
+    this.contentDamService = register(new DummySpiImpl("/content/dam/*"),
         PROPERTY_CONTEXT_PATH_PATTERN, "^/content/dam(/.*)?$",
         SERVICE_RANKING, 200);
-    this.contentSampleService = registerDummySpi(new DummySpiImpl("/content/sample/*[!=exclude]"),
+    this.contentSampleService = register(new DummySpiImpl("/content/sample/*[!=exclude]"),
         PROPERTY_CONTEXT_PATH_PATTERN, "^/content/sample(/.*)?$",
         PROPERTY_CONTEXT_PATH_BLACKLIST_PATTERN, "^/content/sample/exclude(/.*)?$",
         SERVICE_RANKING, 300);
 
     // add some more services with high ranking but invalid properties - they should never be returned
-    registerDummySpi(new DummySpiImpl("invalid1"),
+    register(new DummySpiImpl("invalid1"),
         PROPERTY_CONTEXT_PATH_PATTERN, "(",
         SERVICE_RANKING, 10000);
-    registerDummySpi(new DummySpiImpl("invalid2"),
+    register(new DummySpiImpl("invalid2"),
         PROPERTY_CONTEXT_PATH_PATTERN, "^/content(/.*)?$",
         PROPERTY_CONTEXT_PATH_BLACKLIST_PATTERN, ")",
         SERVICE_RANKING, 20000);
@@ -97,7 +97,7 @@ class TestServices {
   }
 
   DummySpi addDefaultService() {
-    return registerDummySpi(new DummySpiImpl("default"),
+    return register(new DummySpiImpl("default"),
         SERVICE_RANKING, Integer.MIN_VALUE,
         PROPERTY_ACCEPTS_CONTEXT_PATH_EMPTY, true);
   }
@@ -107,12 +107,12 @@ class TestServices {
     // service gets path pattern from bundle header instead of service property
     ((MockBundle)context.bundleContext().getBundle()).setHeaders(ImmutableMap.of(
         PROPERTY_CONTEXT_PATH_PATTERN, "^/content/dam(/.*)?$"));
-    return registerDummySpi(new DummySpiImpl("/content/dam (bundle header)"),
+    return register(new DummySpiImpl("/content/dam (bundle header)"),
         SERVICE_RANKING, 1000);
   }
 
   @SuppressWarnings("null")
-  private DummySpi registerDummySpi(DummySpi service, Object... properties) {
+  private DummySpi register(DummySpi service, Object... properties) {
     Dictionary<String, Object> serviceProperties = MapUtil.toDictionary(properties);
     ServiceRegistration<DummySpi> serviceRegistration = context.bundleContext().registerService(DummySpi.class, service, serviceProperties);
     services.add(new MockServiceObjects<DummySpi>(serviceRegistration.getReference(), service));

--- a/src/test/java/io/wcm/sling/commons/caservice/impl/TestServices.java
+++ b/src/test/java/io/wcm/sling/commons/caservice/impl/TestServices.java
@@ -31,8 +31,8 @@ import java.util.TreeSet;
 
 import org.apache.sling.testing.mock.osgi.MapUtil;
 import org.apache.sling.testing.mock.osgi.MockBundle;
-import org.osgi.framework.ServiceObjects;
 import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.ComponentServiceObjects;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -49,12 +49,13 @@ class TestServices {
   private final DummySpi contentDamService;
   private final DummySpi contentSampleService;
 
-  private final Collection<ServiceObjects<DummySpi>> services = new TreeSet<>(new Comparator<ServiceObjects<DummySpi>>() {
-    @Override
-    public int compare(ServiceObjects<DummySpi> o1, ServiceObjects<DummySpi> o2) {
-      return o2.getServiceReference().compareTo(o1.getServiceReference());
-    }
-  });
+  private final Collection<ComponentServiceObjects<DummySpi>> services = new TreeSet<>(
+      new Comparator<ComponentServiceObjects<DummySpi>>() {
+        @Override
+        public int compare(ComponentServiceObjects<DummySpi> o1, ComponentServiceObjects<DummySpi> o2) {
+          return o2.getServiceReference().compareTo(o1.getServiceReference());
+        }
+      });
 
   TestServices(AemContext context) {
     this.context = context;
@@ -80,7 +81,7 @@ class TestServices {
         SERVICE_RANKING, 20000);
   }
 
-  Collection<ServiceObjects<DummySpi>> getServices() {
+  Collection<ComponentServiceObjects<DummySpi>> getServices() {
     return this.services;
   }
 
@@ -115,7 +116,7 @@ class TestServices {
   private DummySpi register(DummySpi service, Object... properties) {
     Dictionary<String, Object> serviceProperties = MapUtil.toDictionary(properties);
     ServiceRegistration<DummySpi> serviceRegistration = context.bundleContext().registerService(DummySpi.class, service, serviceProperties);
-    services.add(new MockServiceObjects<DummySpi>(serviceRegistration.getReference(), service));
+    services.add(new MockComponentServiceObjects<DummySpi>(serviceRegistration.getReference(), service));
     return service;
   }
 

--- a/src/test/java/io/wcm/sling/commons/caservice/impl/TestServices.java
+++ b/src/test/java/io/wcm/sling/commons/caservice/impl/TestServices.java
@@ -43,8 +43,6 @@ import io.wcm.testing.mock.aem.junit5.AemContext;
  */
 class TestServices {
 
-  private static final String CUSTOM_PROPERTY = "myprop1";
-
   private final AemContext context;
 
   private final DummySpi contentService;
@@ -63,16 +61,13 @@ class TestServices {
 
     this.contentService = registerDummySpi(new DummySpiImpl("/content/*"),
         PROPERTY_CONTEXT_PATH_PATTERN, "^/content(/.*)?$",
-        CUSTOM_PROPERTY, "s1",
         SERVICE_RANKING, 100);
     this.contentDamService = registerDummySpi(new DummySpiImpl("/content/dam/*"),
         PROPERTY_CONTEXT_PATH_PATTERN, "^/content/dam(/.*)?$",
-        CUSTOM_PROPERTY, "s2",
         SERVICE_RANKING, 200);
     this.contentSampleService = registerDummySpi(new DummySpiImpl("/content/sample/*[!=exclude]"),
         PROPERTY_CONTEXT_PATH_PATTERN, "^/content/sample(/.*)?$",
         PROPERTY_CONTEXT_PATH_BLACKLIST_PATTERN, "^/content/sample/exclude(/.*)?$",
-        CUSTOM_PROPERTY, "s3",
         SERVICE_RANKING, 300);
 
     // add some more services with high ranking but invalid properties - they should never be returned


### PR DESCRIPTION
this is a **replacement** for https://github.com/wcm-io/io.wcm.sling.commons/pull/4 because using filter "manually" with the service tracker is kind of an anti-pattern