### PR TITLE
Fix ImmutableMap behavior regarding item order and immutability

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,15 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.6.4" date="not released">
+      <action type="fix" dev="sseifert">
+        ImmutableValueMap.of: Retain order of items as stated in JavaDoc.
+      </action>
+      <action type="fix" dev="sseifert">
+        ImmutableValueMap.copyOf: Ensure map is immutable.
+      </action>
+    </release>
+
     <release version="1.6.2" date="2023-04-19">
       <action type="update" dev="sseifert">
         Switch to Java 11 as minimum version.

--- a/src/main/java/io/wcm/sling/commons/resource/ImmutableValueMap.java
+++ b/src/main/java/io/wcm/sling/commons/resource/ImmutableValueMap.java
@@ -21,7 +21,7 @@ package io.wcm.sling.commons.resource;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -185,9 +185,10 @@ public final class ImmutableValueMap implements ValueMap {
    * @param v1 Value 1
    * @return ImmutableValueMap
    */
-  @SuppressWarnings("null")
   public static @NotNull ImmutableValueMap of(@NotNull String k1, @NotNull Object v1) {
-    return new ImmutableValueMap(Map.of(k1, v1));
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put(k1, v1);
+    return new ImmutableValueMap(Collections.unmodifiableMap(map));
   }
 
   /**
@@ -199,10 +200,12 @@ public final class ImmutableValueMap implements ValueMap {
    * @return ImmutableValueMap
    * @throws IllegalArgumentException if duplicate keys are provided
    */
-  @SuppressWarnings("null")
   public static @NotNull ImmutableValueMap of(@NotNull String k1, @NotNull Object v1,
       @NotNull String k2, @NotNull Object v2) {
-    return new ImmutableValueMap(Map.of(k1, v1, k2, v2));
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put(k1, v1);
+    map.put(k2, v2);
+    return new ImmutableValueMap(Collections.unmodifiableMap(map));
   }
 
   /**
@@ -216,12 +219,15 @@ public final class ImmutableValueMap implements ValueMap {
    * @return ImmutableValueMap
    * @throws IllegalArgumentException if duplicate keys are provided
    */
-  @SuppressWarnings("null")
   public static @NotNull ImmutableValueMap of(
       @NotNull String k1, @NotNull Object v1,
       @NotNull String k2, @NotNull Object v2,
       @NotNull String k3, @NotNull Object v3) {
-    return new ImmutableValueMap(Map.of(k1, v1, k2, v2, k3, v3));
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put(k1, v1);
+    map.put(k2, v2);
+    map.put(k3, v3);
+    return new ImmutableValueMap(Collections.unmodifiableMap(map));
   }
 
   /**
@@ -237,13 +243,18 @@ public final class ImmutableValueMap implements ValueMap {
    * @return ImmutableValueMap
    * @throws IllegalArgumentException if duplicate keys are provided
    */
-  @SuppressWarnings({ "null", "java:S107", "PMD.UseObjectForClearerAPI" })
+  @SuppressWarnings({ "java:S107", "PMD.UseObjectForClearerAPI" })
   public static @NotNull ImmutableValueMap of(
       @NotNull String k1, @NotNull Object v1,
       @NotNull String k2, @NotNull Object v2,
       @NotNull String k3, @NotNull Object v3,
       @NotNull String k4, @NotNull Object v4) {
-    return new ImmutableValueMap(Map.of(k1, v1, k2, v2, k3, v3, k4, v4));
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put(k1, v1);
+    map.put(k2, v2);
+    map.put(k3, v3);
+    map.put(k4, v4);
+    return new ImmutableValueMap(Collections.unmodifiableMap(map));
   }
 
   /**
@@ -261,14 +272,20 @@ public final class ImmutableValueMap implements ValueMap {
    * @return ImmutableValueMap
    * @throws IllegalArgumentException if duplicate keys are provided
    */
-  @SuppressWarnings({ "null", "java:S107", "PMD.UseObjectForClearerAPI" })
+  @SuppressWarnings({ "java:S107", "PMD.UseObjectForClearerAPI" })
   public static ImmutableValueMap of(
       @NotNull String k1, @NotNull Object v1,
       @NotNull String k2, @NotNull Object v2,
       @NotNull String k3, @NotNull Object v3,
       @NotNull String k4, @NotNull Object v4,
       @NotNull String k5, @NotNull Object v5) {
-    return new ImmutableValueMap(Map.of(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5));
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put(k1, v1);
+    map.put(k2, v2);
+    map.put(k3, v3);
+    map.put(k4, v4);
+    map.put(k5, v5);
+    return new ImmutableValueMap(Collections.unmodifiableMap(map));
   }
 
   // looking for of() with > 5 entries? Use the builder instead.
@@ -296,12 +313,7 @@ public final class ImmutableValueMap implements ValueMap {
    * @throws NullPointerException if any key or value in {@code map} is null
    */
   public static @NotNull ImmutableValueMap copyOf(@NotNull Map<String, Object> map) {
-    if (map instanceof ValueMap) {
-      return new ImmutableValueMap((ValueMap)map);
-    }
-    else {
-      return new ImmutableValueMap(map);
-    }
+    return new ImmutableValueMap(Collections.unmodifiableMap(map));
   }
 
   /**
@@ -309,7 +321,7 @@ public final class ImmutableValueMap implements ValueMap {
    */
   public static final class Builder {
 
-    private final @NotNull Map<String, Object> map = new HashMap<>();
+    private final @NotNull Map<String, Object> map = new LinkedHashMap<>();
 
     /**
      * Associates {@code key} with {@code value} in the built map. Duplicate

--- a/src/test/java/io/wcm/sling/commons/resource/ImmutableValueMapTest.java
+++ b/src/test/java/io/wcm/sling/commons/resource/ImmutableValueMapTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Iterator;
 import java.util.Map;
 
 import org.apache.sling.api.resource.ValueMap;
@@ -107,46 +108,31 @@ class ImmutableValueMapTest {
   @Test
   void testOfx1() {
     ValueMap map = ImmutableValueMap.of("p1", "v1");
-    assertEquals(1, map.size());
-    assertEquals("v1", map.get("p1"));
+    assertWithOrder(map, "p1", "v1");
   }
 
   @Test
   void testOfx2() {
-    ValueMap map = ImmutableValueMap.of("p1", "v1", "p2", "v2");
-    assertEquals(2, map.size());
-    assertEquals("v1", map.get("p1"));
-    assertEquals("v2", map.get("p2"));
+    ValueMap map = ImmutableValueMap.of("p2", "v2", "p1", "v1");
+    assertWithOrder(map, "p2", "v2", "p1", "v1");
   }
 
   @Test
   void testOfx3() {
     ValueMap map = ImmutableValueMap.of("p1", "v1", "p2", "v2", "p3", "v3");
-    assertEquals(3, map.size());
-    assertEquals("v1", map.get("p1"));
-    assertEquals("v2", map.get("p2"));
-    assertEquals("v3", map.get("p3"));
+    assertWithOrder(map, "p1", "v1", "p2", "v2", "p3", "v3");
   }
 
   @Test
   void testOfx4() {
-    ValueMap map = ImmutableValueMap.of("p1", "v1", "p2", "v2", "p3", "v3", "p4", "v4");
-    assertEquals(4, map.size());
-    assertEquals("v1", map.get("p1"));
-    assertEquals("v2", map.get("p2"));
-    assertEquals("v3", map.get("p3"));
-    assertEquals("v4", map.get("p4"));
+    ValueMap map = ImmutableValueMap.of("p3", "v3", "p2", "v2", "p1", "v1", "p4", "v4");
+    assertWithOrder(map, "p3", "v3", "p2", "v2", "p1", "v1", "p4", "v4");
   }
 
   @Test
   void testOfx5() {
-    ValueMap map = ImmutableValueMap.of("p1", "v1", "p2", "v2", "p3", "v3", "p4", "v4", "p5", "v5");
-    assertEquals(5, map.size());
-    assertEquals("v1", map.get("p1"));
-    assertEquals("v2", map.get("p2"));
-    assertEquals("v3", map.get("p3"));
-    assertEquals("v4", map.get("p4"));
-    assertEquals("v5", map.get("p5"));
+    ValueMap map = ImmutableValueMap.of("p1", "v1", "p5", "v5", "p3", "v3", "p4", "v4", "p2", "v2");
+    assertWithOrder(map, "p1", "v1", "p5", "v5", "p3", "v3", "p4", "v4", "p2", "v2");
   }
 
   @Test
@@ -209,6 +195,19 @@ class ImmutableValueMapTest {
     assertEquals("{prop0=true, prop1=value1, prop2=55}", map.toString());
 
     assertEquals("{}", ImmutableValueMap.of().toString());
+  }
+
+  private void assertWithOrder(Map<String, Object> map, Object... items) {
+    int count = items.length / 2;
+    assertEquals(count, map.size(), "map size");
+    Iterator<Map.Entry<String, Object>> entries = map.entrySet().iterator();
+    for (int i = 0; i < items.length - 1; i = i + 2) {
+      Object key = items[i];
+      Object value = items[i + 1];
+      Map.Entry<String, Object> entry = entries.next();
+      assertEquals(key, entry.getKey(), "Key Entry #" + (i / 2));
+      assertEquals(value, entry.getValue(), "Value Entry #" + (i / 2));
+    }
   }
 
 }


### PR DESCRIPTION
* ImmutableValueMap.of: Retain order of items as stated in JavaDoc.
* ImmutableValueMap.copyOf: Ensure map is immutable.